### PR TITLE
Fix: Cover test sources in the TypeScript project

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,24 @@ npm test
 
 The unit suites cover the HTTP security boundary, configuration validation, filename sanitization, disk measurement, and the file CIDs issued before the Helia migration. The integration suite starts two isolated nodes with temporary stores, transfers a file between them over bitswap, and verifies that a peer identity survives a restart.
 
+### TypeScript project layout
+
+Three configurations share one set of compiler options:
+
+| File                  | Purpose                                                               |
+| --------------------- | --------------------------------------------------------------------- |
+| `tsconfig.json`       | Type-checks `src` and `test`. Emits nothing; this is what editors use |
+| `tsconfig.build.json` | Builds `src` into `dist` for `npm run build`                          |
+| `tsconfig.test.json`  | Builds `src` and `test` into `dist-test` for `npm test`               |
+
+Type-check everything without emitting:
+
+```bash
+npx tsc --noEmit
+```
+
+Pass no file arguments to `tsc`. Naming a file on the command line makes TypeScript ignore `tsconfig.json` entirely, so `outDir` is not applied — the `.js` file is written next to its source — and the project's `lib`, `module`, and `moduleResolution` settings are replaced by defaults, which reports module-resolution and missing-`@types/node` errors that the project itself does not have.
+
 ## API usage
 
 ### Upload files

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rimraf dist && tsc",
+    "build": "rimraf dist && tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
     "dev": "nodemon",
     "lint": "eslint .",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  // Application build: `src` only, emitted to `dist`.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,9 @@
 {
+  // Project-wide configuration. Editors resolve a file to the nearest
+  // tsconfig.json, so this one must cover every type-checked file; anything it
+  // misses is type-checked by the editor under default compiler options, which
+  // report spurious errors about module resolution and missing Node typings.
+  // It never emits: `tsconfig.build.json` and `tsconfig.test.json` do that.
   "compilerOptions": {
     "allowJs": false,
     "checkJs": false,
@@ -11,8 +16,8 @@
     "noImplicitAny": true,
     "useUnknownInCatchVariables": false,
     "skipLibCheck": true,
-    "outDir": "./dist"
+    "noEmit": true
   },
-  "exclude": ["node_modules"],
-  "include": ["src/index.ts", "src/**/*.ts"]
+  "exclude": ["node_modules", "dist", "dist-test"],
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,8 @@
 {
+  // Test build: `src` and `test`, emitted to `dist-test` preserving both trees.
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "outDir": "./dist-test",
     "rootDir": "."
   },


### PR DESCRIPTION
## Description

Editors reported module-resolution and missing-`@types/node` errors on files under `test/`, and `outDir` appeared not to apply. Neither `npm run build` nor `npm test` reproduces any of it — both type-check clean.

The cause is project coverage. `tsconfig.json` listed `["src/index.ts", "src/**/*.ts"]`, so `test/**` belonged to no TypeScript project. An editor resolves a file to the nearest `tsconfig.json`; when that config does not list the file, the file is type-checked under default compiler options instead of the project's `lib`, `module`, and `moduleResolution`, which produces errors the project itself does not have.

The single configuration is split in three so the project-wide file can cover every type-checked source without changing what the builds emit:

| File | Purpose |
| --- | --- |
| `tsconfig.json` | Type-checks `src` and `test`, emits nothing. This is what editors use |
| `tsconfig.build.json` | Builds `src` into `dist` for `npm run build` |
| `tsconfig.test.json` | Builds `src` and `test` into `dist-test` for `npm test` |

Also in this change:

- `rootDir` is explicit in both build configurations instead of being inferred from the common ancestor of the input files, so adding a source file outside `src` cannot silently shift the output layout
- `dist` and `dist-test` are excluded, so compiler output can never become compiler input
- `README.md` documents the layout and records that naming a file on the `tsc` command line bypasses `tsconfig.json` entirely, which leaves `outDir` unapplied and writes the `.js` next to its source

Emitted output is unchanged: `npm run build` still produces `dist/index.js` with the same tree, and `npm test` still produces `dist-test/src` and `dist-test/test`.

## Related issue

Follow-up to #21, whose runtime migration is already on `dev` as a1470a6.

## How to test

Type-check the whole project the way an editor does, with no file arguments:

```bash
npx tsc --noEmit
```

Then confirm both builds still emit where they did before:

```bash
npm run build && ls dist/index.js
```

```bash
npm test
```

Opening any file under `test/` in an editor should no longer report module-resolution or `@types/node` errors.

### Validation performed

All commands were run on Node.js v24.19.0.

- `npx tsc --noEmit` — clean across `src` and `test`
- `npm run build` — emits `dist/index.js`, tree unchanged
- `npm run test:build` — emits `dist-test/src` and `dist-test/test`, unchanged
- `npm test` — 57 unit and 8 integration tests passing
- `npm run lint`, `npm run format`, `npx markdownlint-cli2 README.md` — clean
- `npm run security:audit` — no high or critical production findings
- `npm run security:semgrep` — 86 rules, 33 targets, 0 findings

## Checklist

- [x] Editors type-check `test/**` against the project configuration
- [x] `npm run build` and `npm test` emit exactly what they emitted before
- [x] `rootDir` is explicit rather than inferred
- [x] Compiler output directories cannot be picked up as input
- [x] Documentation matches the current configuration

## Notes

The reported `ts(2591)` text names `node:crypto`; that diagnostic is raised for an identifier, and an unresolved `import ... from 'node:crypto'` raises `ts(2307)` instead, which was confirmed against a checkout without `@types/node`. The exact wording could not be reproduced, so if it persists after this change, please share the file and line — the fix here addresses the project-coverage cause behind that family of editor errors, not a specific reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
