### PR TITLE
Feat: Add network-aware health and reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
   "serverPort": 4000,
   "uploadLimitSizeBytes": 268435456,
   "maxFileCount": 10,
+  "findFileTimeout": 20000,
+  "downloadIdleTimeout": 20000,
+  "downloadMinBytesPerSecond": 32768,
   "cors": {
     "allowedOrigins": ["https://adm.im", "https://*.adamant.im", "http://localhost:8080"]
   },
@@ -85,7 +88,8 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
     "requireQuorumOnUpload": false,
     "requestTimeoutMs": 30000,
     "repairEnabled": true,
-    "repairSchedule": "0 */30 * * * *"
+    "repairSchedule": "0 */30 * * * *",
+    "repairBatchDelayMs": 1000
   },
   "health": {
     "checkpointIntervalMs": 60000,
@@ -98,6 +102,11 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
   }
 }
 ```
+
+`findFileTimeout` bounds discovery, while `downloadIdleTimeout` (defaulting to
+`findFileTimeout`) bounds a stalled transfer. `downloadMinBytesPerSecond`
+(default `32768`) derives a complete-transfer deadline from the file size, so a
+large active download is not cut off by the short discovery timeout.
 
 `storage`, `replication`, and `health` are optional; every option falls back to a documented default, so an existing configuration file keeps working. Storage and replication are described in [docs/storage-lifecycle.md](docs/storage-lifecycle.md), together with the file states, the collection policy, and the recovery procedures.
 
@@ -351,10 +360,9 @@ Download responses use the following stable status contract:
 | `400 Bad Request`           | The CID is invalid                                                     |
 | `408 Request Timeout`       | The file could not be found or retrieved before the configured timeout |
 | `429 Too Many Requests`     | The read rate limit was exceeded                                       |
-| `416 Range Not Satisfiable` | Range retrieval is intentionally unsupported                           |
 | `500 Internal Server Error` | An unexpected internal failure occurred before streaming started       |
 
-The timeout covers the complete transfer, not only discovery or the first chunk, and remains `408 Request Timeout` for compatibility with existing clients. Client disconnect cancels the underlying retrieval. Successful immutable-CID responses include `ETag`, long-lived immutable caching, and `Accept-Ranges: none`. If an error occurs after response bytes have started, the server terminates the incomplete response because an HTTP status and JSON error body can no longer be sent safely.
+Discovery, idle transfer time, and the size-aware complete transfer all have bounded timeouts and remain `408 Request Timeout` for compatibility with existing clients. Client disconnect cancels the underlying retrieval. Range headers are ignored and the server returns the complete `200` representation with `Accept-Ranges: none`, preserving current PWA/iOS behavior. Successful responses include an `ETag` and private one-hour caching with revalidation; a matching `If-None-Match` returns `304` after availability has been checked. If an error occurs after response bytes have started, the server terminates the incomplete response because an HTTP status and JSON error body can no longer be sent safely.
 
 ### Check public health
 
@@ -386,8 +394,7 @@ Example response:
   "storage": {
     "measuredAt": 1720614980000,
     "measurementAgeMs": 18797,
-    "availableBytes": 8589934592,
-    "reservedBytes": 5368709120
+    "reserveHealthy": true
   },
   "replication": {
     "repairRequired": true,
@@ -407,6 +414,10 @@ Example response:
 ```
 
 The endpoint always returns `200`; consumers must inspect `state`. `height` is a persisted, monotonic Unix-millisecond checkpoint at the start of a fixed round. It advances only when startup reconciliation, storage freshness and reserve, a complete successful repair cycle with no known backlog, and the configured peer attestations all pass. It freezes on failure. Observation timestamps and ages let clients reject an absolutely stale cluster even when every node reports the same height. `starting`, `degraded`, and `stale` distinguish warm-up, a current failed prerequisite, and an expired last checkpoint.
+
+`membership.version` identifies the configured peer-set epoch. Changing the node list resets the persisted checkpoint for that node: `height` remains `0` until the first valid checkpoint under the new membership. Clients must compare heights only when membership versions match and treat a version change as a new epoch.
+
+Repair runs in bounded 50-record passes. A scheduled run starts a full cycle immediately and continues its remaining passes after `replication.repairBatchDelayMs`; `repairSchedule` controls when a new completed cycle is refreshed. Set `health.repairMaxAgeMs` longer than the largest expected full-cycle duration plus the schedule interval. An incomplete or backlogged cycle intentionally keeps health degraded.
 
 ### Get legacy client node information
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This service embeds a Helia/libp2p node and exposes the file-transfer API used b
 
 The application is not a Kubo wrapper. It is a Node.js service with an Express REST API around an in-process Helia node.
 
+The stable client and lifecycle contract is also available as [OpenAPI 3.1](docs/openapi.yaml).
+
 ## Requirements
 
 - Node.js 24 LTS. The repository ships an `.nvmrc`, so `nvm use` selects it
@@ -57,6 +59,7 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
   },
   "adminApiKey": "",
   "enableDebugApi": false,
+  "prettyLogs": false,
   "peeringSchedule": "*/30 * * * * *",
   "storage": {
     "maxRequestSizeBytes": 536870912,
@@ -83,11 +86,22 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
     "requestTimeoutMs": 30000,
     "repairEnabled": true,
     "repairSchedule": "0 */30 * * * *"
+  },
+  "health": {
+    "checkpointIntervalMs": 60000,
+    "maxCheckpointAgeMs": 180000,
+    "storageMaxAgeMs": 120000,
+    "repairMaxAgeMs": 3600000,
+    "clockSkewToleranceMs": 10000,
+    "peerAttestationTimeoutMs": 5000,
+    "requiredPeerCount": 1
   }
 }
 ```
 
-`storage` and `replication` are optional; every option falls back to a documented default, so an existing configuration file keeps working. Both sections are described in [docs/storage-lifecycle.md](docs/storage-lifecycle.md), together with the file states, the collection policy, and the recovery procedures.
+`storage`, `replication`, and `health` are optional; every option falls back to a documented default, so an existing configuration file keeps working. Storage and replication are described in [docs/storage-lifecycle.md](docs/storage-lifecycle.md), together with the file states, the collection policy, and the recovery procedures.
+
+Logs are newline-delimited JSON by default. Set `prettyLogs: true` only for an interactive development terminal; production collectors should keep the structured fields emitted by Pino and the health checkpoint.
 
 Generate the administrative secret before enabling operator endpoints:
 
@@ -110,21 +124,22 @@ Set the generated value as `adminApiKey`. A missing or empty key fails closed: a
 - `storage.gc.enabled` is on by default and frees blocks only when the blockstore passes `highWatermarkBytes` or free space falls into `diskReserveBytes`; released files stay readable until then
 - `replication.enabled` is on by default and needs no key and no extra address: copies travel on a libp2p protocol between the peers already listed in `nodes`. Turning it off leaves every file in a single copy
 - Tune `replication.placement` if the deployment wants a different number of copies per file age
+- Keep `health.requiredPeerCount` within the number of configured remote peers. A single-node or test deployment may set it to `0`
 - `peeringSchedule` is optional and defaults to every thirty seconds; it redials the peers in `nodes` that are not connected, which `autoPeeringPeriod` never did
 
 Invalid CORS, proxy, API-key, or rate-limit configuration stops the process instead of silently weakening the boundary.
 
 ## HTTP access policy
 
-| Class                | Routes                                                                                                                                                 | Policy                                                                                                                                                                                                                                |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Public               | `GET /`, `GET /api/node/health`                                                                                                                        | No authentication                                                                                                                                                                                                                     |
-| Public file transfer | `POST /api/file/upload`, `GET /api/file/:cid`                                                                                                          | No authentication; endpoint-specific rate limits and upload limits apply                                                                                                                                                              |
-| Public storage state | `GET /api/file/:cid/status`, `GET /api/storage/metrics`, `GET /api/storage/policy`                                                                     | No authentication; no filename or peer topology is exposed                                                                                                                                                                            |
-| Administrative       | `GET /api/node/info`, `POST /api/file/:cid/confirm`, `POST /api/file/:cid/unpin`, all `/api/storage/*` writes, all `/api/helia/*`, all `/api/libp2p/*` | A matching `x-api-key` header is required                                                                                                                                                                                             |
-| Peer replication     | libp2p `/adamant/replication/1.0.0`, not an HTTP route                                                                                                 | Authenticated by the libp2p handshake. Pin, store, stage, commit, and abort are accepted only from the peers listed in `nodes`. `cache` is open to any peer (same effect as a public read), bounded by disk reserve and intake budget |
-| Disabled by default  | all `/api/debug/*`                                                                                                                                     | Not mounted unless `enableDebugApi` is `true`; still requires `x-api-key`                                                                                                                                                             |
-| Authenticated user   | None                                                                                                                                                   | The service has no end-user identity or session layer                                                                                                                                                                                 |
+| Class                | Routes                                                                                                                                                    | Policy                                                                                                                                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public               | `GET /`, `GET /api/node/health`, `GET /api/node/info`                                                                                                     | No authentication. `/info` is the sanitized legacy PWA/iOS contract                                                                                                                         |
+| Public file transfer | `POST /api/file/upload`, `GET /api/file/:cid`                                                                                                             | No authentication; endpoint-specific rate limits and upload limits apply                                                                                                                    |
+| Public storage state | `GET /api/file/:cid/status`, `GET /api/storage/metrics`, `GET /api/storage/policy`                                                                        | No authentication; no filename or peer topology is exposed                                                                                                                                  |
+| Administrative       | `GET /api/node/details`, `POST /api/file/:cid/confirm`, `POST /api/file/:cid/unpin`, all `/api/storage/*` writes, all `/api/helia/*`, all `/api/libp2p/*` | A matching `x-api-key` header is required                                                                                                                                                   |
+| Peer protocols       | libp2p `/adamant/replication/1.0.0` and `/adamant/health/1.0.0`, not HTTP routes                                                                          | Authenticated by the libp2p handshake. Health attestations and durable replication operations are accepted only from peers listed in `nodes`; open cache remains bounded like a public read |
+| Disabled by default  | all `/api/debug/*`                                                                                                                                        | Not mounted unless `enableDebugApi` is `true`; still requires `x-api-key`                                                                                                                   |
+| Authenticated user   | None                                                                                                                                                      | The service has no end-user identity or session layer                                                                                                                                       |
 
 Administrative coverage includes pin operations, dial operations, peer-store data, connection data, status, peers, and topology-sensitive node information. CORS is a browser control and is never treated as authentication.
 
@@ -228,7 +243,7 @@ Three configurations share one set of compiler options:
 Type-check everything without emitting:
 
 ```bash
-npx tsc --noEmit
+npm run typecheck
 ```
 
 Pass no file arguments to `tsc`. Naming a file on the command line makes TypeScript ignore `tsconfig.json` entirely, so `outDir` is not applied — the `.js` file is written next to its source — and the project's `lib`, `module`, and `moduleResolution` settings are replaced by defaults, which reports module-resolution and missing-`@types/node` errors that the project itself does not have.
@@ -336,9 +351,10 @@ Download responses use the following stable status contract:
 | `400 Bad Request`           | The CID is invalid                                                     |
 | `408 Request Timeout`       | The file could not be found or retrieved before the configured timeout |
 | `429 Too Many Requests`     | The read rate limit was exceeded                                       |
+| `416 Range Not Satisfiable` | Range retrieval is intentionally unsupported                           |
 | `500 Internal Server Error` | An unexpected internal failure occurred before streaming started       |
 
-The timeout status remains `408 Request Timeout` for compatibility with existing clients. If an error occurs after response bytes have started, the server terminates the incomplete response because an HTTP status and JSON error body can no longer be sent safely.
+The timeout covers the complete transfer, not only discovery or the first chunk, and remains `408 Request Timeout` for compatibility with existing clients. Client disconnect cancels the underlying retrieval. Successful immutable-CID responses include `ETag`, long-lived immutable caching, and `Accept-Ranges: none`. If an error occurs after response bytes have started, the server terminates the incomplete response because an HTTP status and JSON error body can no longer be sent safely.
 
 ### Check public health
 
@@ -350,18 +366,42 @@ Example response:
 
 ```json
 {
+  "status": "ready",
+  "height": 1720614960000,
   "timestamp": 1720614998797,
-  "heliaStatus": "started"
+  "checkpointIntervalMs": 60000,
+  "membershipVersion": "d0f1...",
+  "checks": {
+    "helia": true,
+    "startupReconciliation": true,
+    "storageFresh": true,
+    "storageReserve": true,
+    "repairFresh": true,
+    "peerAttestations": true
+  },
+  "peerAttestations": { "required": 1, "received": 2 }
 }
 ```
+
+The endpoint always returns `200`; consumers must inspect `status`. `height` is a persisted, monotonic Unix-millisecond checkpoint at the start of a fixed round. It advances only when startup reconciliation, storage freshness and reserve, a complete successful repair cycle, and the configured peer attestations all pass. It freezes on failure. `starting`, `degraded`, and `stale` distinguish warm-up, a current failed prerequisite, and an expired last checkpoint.
+
+### Get legacy client node information
+
+```bash
+curl --fail-with-body https://ipfs.example.org/api/node/info
+```
+
+This public compatibility route retains `version`, `timestamp`, `heliaStatus`, `blockstoreSizeMb`, `datastoreSizeMb`, and `availableSizeInMb` for the current PWA and iOS application. It does not expose peer identity or topology.
 
 ### Get administrative node information
 
 ```bash
 curl --fail-with-body \
   --header 'x-api-key: your-generated-key' \
-  https://ipfs.example.org/api/node/info
+  https://ipfs.example.org/api/node/details
 ```
+
+The authenticated response adds peer addresses, byte-accurate storage figures, checkpoint detail, and bounded HTTP counters without paths, CIDs, IP addresses, or user-controlled metric labels.
 
 ### Run garbage collection
 

--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Example response:
   "state": "ready",
   "height": 1720614960000,
   "timestamp": 1720614998797,
+  "evaluatedAt": 1720614998700,
   "checkpoint": {
     "intervalMs": 60000,
     "observedAt": 1720614998700,
@@ -431,7 +432,7 @@ Example response:
 
 The endpoint always returns `200`; consumers must inspect `state`. `height` is a persisted, monotonic Unix-millisecond checkpoint at the start of a fixed round. It advances only when startup reconciliation, storage freshness and reserve, a complete successful repair cycle with no known backlog, and the configured peer attestations all pass. It freezes on failure. Observation timestamps and ages let clients reject an absolutely stale cluster even when every node reports the same height. `starting`, `degraded`, and `stale` distinguish warm-up, a current failed prerequisite, and an expired last checkpoint.
 
-State changes are deliberately asymmetric. The response is served from the last checkpoint, and reading it recomputes only what elapsed time can decide, so a node may be downgraded to `degraded` or `stale` between checkpoints. Recovery is never decided on a read: returning to `ready` requires a successful checkpoint, so expect up to `health.checkpointIntervalMs` of lag after the underlying fault clears. `checkpointFresh`, `storageFresh`, and `repairFresh` follow the same rule; every other entry in `checks`, along with `membership` and `startup`, describes the moment identified by `checkpoint.observedAt` and not the moment of the request. Peers may attest an adjacent round across a boundary, so two healthy nodes can briefly report heights one `checkpointIntervalMs` apart.
+State changes are deliberately asymmetric. The response is served from the last checkpoint, and reading it recomputes only what elapsed time can decide, so a node may be downgraded to `degraded` or `stale` between checkpoints. Recovery is never decided on a read: returning to `ready` requires a successful checkpoint, so expect up to `health.checkpointIntervalMs` of lag after the underlying fault clears. `checkpointFresh`, `storageFresh`, and `repairFresh` follow the same rule; every other entry in `checks`, along with `membership` and `startup`, describes `evaluatedAt` — the last checkpoint attempt, which may be a failed one — and not the moment of the request. `checkpoint.observedAt` dates the last attempt that _succeeded_, so the two differ whenever the most recent attempt failed. Peers may attest an adjacent round across a boundary, so two healthy nodes can briefly report heights one `checkpointIntervalMs` apart.
 
 `membership.version` identifies the configured peer-set epoch. Changing the node list resets the persisted checkpoint for that node: `height` remains `0` until the first valid checkpoint under the new membership. Clients must compare heights only when membership versions match and treat a version change as a new epoch.
 

--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Example response:
   },
   "checks": {
     "checkpointFresh": true,
+    "clockConsistent": true,
     "helia": true,
     "startupReconciliation": true,
     "storageFresh": true,
@@ -432,7 +433,7 @@ Example response:
 
 The endpoint always returns `200`; consumers must inspect `state`. `height` is a persisted, monotonic Unix-millisecond checkpoint at the start of a fixed round. It advances only when startup reconciliation, storage freshness and reserve, a complete successful repair cycle with no known backlog, and the configured peer attestations all pass. It freezes on failure. Observation timestamps and ages let clients reject an absolutely stale cluster even when every node reports the same height. `starting`, `degraded`, and `stale` distinguish warm-up, a current failed prerequisite, and an expired last checkpoint.
 
-State changes are deliberately asymmetric. The response is served from the last checkpoint, and reading it recomputes only what elapsed time can decide, so a node may be downgraded to `degraded` or `stale` between checkpoints. Recovery is never decided on a read: returning to `ready` requires a successful checkpoint, so expect up to `health.checkpointIntervalMs` of lag after the underlying fault clears. `checkpointFresh`, `storageFresh`, and `repairFresh` follow the same rule; every other entry in `checks`, along with `membership` and `startup`, describes `evaluatedAt` — the last checkpoint attempt, which may be a failed one — and not the moment of the request. `checkpoint.observedAt` dates the last attempt that _succeeded_, so the two differ whenever the most recent attempt failed. Peers may attest an adjacent round across a boundary, so two healthy nodes can briefly report heights one `checkpointIntervalMs` apart.
+State changes are deliberately asymmetric. The response is served from the last checkpoint, and reading it recomputes only what elapsed time can decide, so a node may be downgraded to `degraded` or `stale` between checkpoints. Recovery is never decided on a read: returning to `ready` requires a successful checkpoint, so expect up to `health.checkpointIntervalMs` of lag after the underlying fault clears. A clock that moves behind the checkpoint this node already recorded clears `clockConsistent` and stops advancement until it catches up, rather than persisting a round that starts after it finished. `checkpointFresh`, `storageFresh`, and `repairFresh` follow the same rule; every other entry in `checks`, along with `membership` and `startup`, describes `evaluatedAt` — the last checkpoint attempt, which may be a failed one — and not the moment of the request. `checkpoint.observedAt` dates the last attempt that _succeeded_, so the two differ whenever the most recent attempt failed. Peers may attest an adjacent round across a boundary, so two healthy nodes can briefly report heights one `checkpointIntervalMs` apart.
 
 `membership.version` identifies the configured peer-set epoch. Changing the node list resets the persisted checkpoint for that node: `height` remains `0` until the first valid checkpoint under the new membership. Clients must compare heights only when membership versions match and treat a version change as a new epoch.
 

--- a/README.md
+++ b/README.md
@@ -366,11 +366,35 @@ Example response:
 
 ```json
 {
-  "status": "ready",
+  "version": "0.1.0",
+  "uptimeMs": 123456,
+  "state": "ready",
   "height": 1720614960000,
   "timestamp": 1720614998797,
-  "checkpointIntervalMs": 60000,
-  "membershipVersion": "d0f1...",
+  "checkpoint": {
+    "intervalMs": 60000,
+    "observedAt": 1720614998700,
+    "ageMs": 97,
+    "maxAgeMs": 180000
+  },
+  "membership": {
+    "version": "d0f1...",
+    "requiredPeers": 1,
+    "attestedPeers": 2
+  },
+  "startup": { "complete": true, "healthy": true },
+  "storage": {
+    "measuredAt": 1720614980000,
+    "measurementAgeMs": 18797,
+    "availableBytes": 8589934592,
+    "reservedBytes": 5368709120
+  },
+  "replication": {
+    "repairRequired": true,
+    "lastCompleteAt": 1720614900000,
+    "ageMs": 98797,
+    "backlog": 0
+  },
   "checks": {
     "helia": true,
     "startupReconciliation": true,
@@ -378,12 +402,11 @@ Example response:
     "storageReserve": true,
     "repairFresh": true,
     "peerAttestations": true
-  },
-  "peerAttestations": { "required": 1, "received": 2 }
+  }
 }
 ```
 
-The endpoint always returns `200`; consumers must inspect `status`. `height` is a persisted, monotonic Unix-millisecond checkpoint at the start of a fixed round. It advances only when startup reconciliation, storage freshness and reserve, a complete successful repair cycle, and the configured peer attestations all pass. It freezes on failure. `starting`, `degraded`, and `stale` distinguish warm-up, a current failed prerequisite, and an expired last checkpoint.
+The endpoint always returns `200`; consumers must inspect `state`. `height` is a persisted, monotonic Unix-millisecond checkpoint at the start of a fixed round. It advances only when startup reconciliation, storage freshness and reserve, a complete successful repair cycle with no known backlog, and the configured peer attestations all pass. It freezes on failure. Observation timestamps and ages let clients reject an absolutely stale cluster even when every node reports the same height. `starting`, `degraded`, and `stale` distinguish warm-up, a current failed prerequisite, and an expired last checkpoint.
 
 ### Get legacy client node information
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
     "maxRequestSizeBytes": 536870912,
     "maxConcurrentUploads": 32,
     "maxConcurrentDownloads": 64,
+    "maxConcurrentDownloadsPerClient": 8,
     "diskReserveBytes": 5368709120,
     "confirmationRequired": false,
     "temporaryTtlMs": 86400000,
@@ -111,8 +112,15 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
 (default `32768`) derives a complete-transfer deadline from the file size, while
 `downloadMaxDurationMs` (default four hours) provides an absolute ceiling.
 `storage.maxConcurrentDownloads` (default `64`) bounds sockets and UnixFS
-iterators globally. Discovery, stat, and streaming have separate bounds, so a
-failed request may spend more than one `findFileTimeout` before returning `408`.
+iterators globally, and `storage.maxConcurrentDownloadsPerClient` (default `8`)
+keeps one address from holding every slot. Discovery, stat, and streaming have
+separate bounds, so a failed request may spend more than one `findFileTimeout`
+before returning `408`.
+
+Startup refuses a `downloadMaxDurationMs` below the time `uploadLimitSizeBytes`
+needs at `downloadMinBytesPerSecond`: the ceiling wins over the size-aware
+deadline, so a lower value would cut the largest permitted files off mid-stream
+and report them as retrieval timeouts.
 
 `storage`, `replication`, and `health` are optional; every option falls back to a documented default, so an existing configuration file keeps working. Storage and replication are described in [docs/storage-lifecycle.md](docs/storage-lifecycle.md), together with the file states, the collection policy, and the recovery procedures.
 
@@ -423,9 +431,11 @@ Example response:
 
 The endpoint always returns `200`; consumers must inspect `state`. `height` is a persisted, monotonic Unix-millisecond checkpoint at the start of a fixed round. It advances only when startup reconciliation, storage freshness and reserve, a complete successful repair cycle with no known backlog, and the configured peer attestations all pass. It freezes on failure. Observation timestamps and ages let clients reject an absolutely stale cluster even when every node reports the same height. `starting`, `degraded`, and `stale` distinguish warm-up, a current failed prerequisite, and an expired last checkpoint.
 
+State changes are deliberately asymmetric. The response is served from the last checkpoint, and reading it recomputes only what elapsed time can decide, so a node may be downgraded to `degraded` or `stale` between checkpoints. Recovery is never decided on a read: returning to `ready` requires a successful checkpoint, so expect up to `health.checkpointIntervalMs` of lag after the underlying fault clears. `checkpointFresh`, `storageFresh`, and `repairFresh` follow the same rule; every other entry in `checks`, along with `membership` and `startup`, describes the moment identified by `checkpoint.observedAt` and not the moment of the request. Peers may attest an adjacent round across a boundary, so two healthy nodes can briefly report heights one `checkpointIntervalMs` apart.
+
 `membership.version` identifies the configured peer-set epoch. Changing the node list resets the persisted checkpoint for that node: `height` remains `0` until the first valid checkpoint under the new membership. Clients must compare heights only when membership versions match and treat a version change as a new epoch.
 
-During a staged deployment, older peers do not implement the health protocol. Set `health.requiredPeerCount` to `0` on the transitioning fleet, then raise it after every required peer is upgraded; otherwise prolonged `degraded` health is the expected fail-safe result.
+During a staged deployment, older peers do not implement the health protocol. Set `health.requiredPeerCount` to `0` on the transitioning fleet, then raise it after every required peer is upgraded; otherwise prolonged `degraded` health is the expected fail-safe result. While it is `0`, `checks.peerAttestations` is always `true` and the checkpoint proves only this node's own prerequisites: network coverage is not validated until the threshold is raised, so treat the transition window as unverified for routing decisions that depend on it.
 
 Repair runs in bounded 50-record passes. The same selected batch feeds both local-holder repair and released-record rescue. A scheduled run starts a full cycle immediately and continues its remaining passes after `replication.repairBatchDelayMs`; this delay and `replication.repairProbeConcurrency` control peer load, while `repairSchedule` controls when a new completed cycle is refreshed. Set `health.repairMaxAgeMs` longer than the largest expected full-cycle duration plus the schedule interval. An incomplete or backlogged cycle intentionally keeps health degraded.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
   "findFileTimeout": 20000,
   "downloadIdleTimeout": 20000,
   "downloadMinBytesPerSecond": 32768,
+  "downloadMaxDurationMs": 14400000,
   "cors": {
     "allowedOrigins": ["https://adm.im", "https://*.adamant.im", "http://localhost:8080"]
   },
@@ -67,6 +68,7 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
   "storage": {
     "maxRequestSizeBytes": 536870912,
     "maxConcurrentUploads": 32,
+    "maxConcurrentDownloads": 64,
     "diskReserveBytes": 5368709120,
     "confirmationRequired": false,
     "temporaryTtlMs": 86400000,
@@ -89,7 +91,8 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
     "requestTimeoutMs": 30000,
     "repairEnabled": true,
     "repairSchedule": "0 */30 * * * *",
-    "repairBatchDelayMs": 1000
+    "repairBatchDelayMs": 1000,
+    "repairProbeConcurrency": 4
   },
   "health": {
     "checkpointIntervalMs": 60000,
@@ -105,8 +108,11 @@ The whole configuration is validated at startup: a missing file, invalid JSON5, 
 
 `findFileTimeout` bounds discovery, while `downloadIdleTimeout` (defaulting to
 `findFileTimeout`) bounds a stalled transfer. `downloadMinBytesPerSecond`
-(default `32768`) derives a complete-transfer deadline from the file size, so a
-large active download is not cut off by the short discovery timeout.
+(default `32768`) derives a complete-transfer deadline from the file size, while
+`downloadMaxDurationMs` (default four hours) provides an absolute ceiling.
+`storage.maxConcurrentDownloads` (default `64`) bounds sockets and UnixFS
+iterators globally. Discovery, stat, and streaming have separate bounds, so a
+failed request may spend more than one `findFileTimeout` before returning `408`.
 
 `storage`, `replication`, and `health` are optional; every option falls back to a documented default, so an existing configuration file keeps working. Storage and replication are described in [docs/storage-lifecycle.md](docs/storage-lifecycle.md), together with the file states, the collection policy, and the recovery procedures.
 
@@ -127,6 +133,7 @@ Set the generated value as `adminApiKey`. A missing or empty key fails closed: a
 - Use exact origins such as `https://adm.im` or any-depth subdomain suffix wildcards such as `https://*.adamant.im`
 - Set `adminApiKey` before using any administrative API
 - Leave `trustProxy` as `false` for direct connections; configure exact proxy addresses, CIDR ranges, or a verified hop count behind a proxy
+- Migrate operator scripts and dashboards from the former detailed `GET /api/node/info` response to authenticated `GET /api/node/details`; `/info` is now the public legacy PWA/iOS contract
 - Set `enableDebugApi: true` only when the authenticated debug route is operationally required
 - Tune the endpoint-specific `rateLimits` for the deployment perimeter
 - Review `storage.diskReserveBytes` and `storage.maxRequestSizeBytes` for the deployment volume; the defaults suit a dedicated disk
@@ -403,6 +410,7 @@ Example response:
     "backlog": 0
   },
   "checks": {
+    "checkpointFresh": true,
     "helia": true,
     "startupReconciliation": true,
     "storageFresh": true,
@@ -417,7 +425,9 @@ The endpoint always returns `200`; consumers must inspect `state`. `height` is a
 
 `membership.version` identifies the configured peer-set epoch. Changing the node list resets the persisted checkpoint for that node: `height` remains `0` until the first valid checkpoint under the new membership. Clients must compare heights only when membership versions match and treat a version change as a new epoch.
 
-Repair runs in bounded 50-record passes. A scheduled run starts a full cycle immediately and continues its remaining passes after `replication.repairBatchDelayMs`; `repairSchedule` controls when a new completed cycle is refreshed. Set `health.repairMaxAgeMs` longer than the largest expected full-cycle duration plus the schedule interval. An incomplete or backlogged cycle intentionally keeps health degraded.
+During a staged deployment, older peers do not implement the health protocol. Set `health.requiredPeerCount` to `0` on the transitioning fleet, then raise it after every required peer is upgraded; otherwise prolonged `degraded` health is the expected fail-safe result.
+
+Repair runs in bounded 50-record passes. The same selected batch feeds both local-holder repair and released-record rescue. A scheduled run starts a full cycle immediately and continues its remaining passes after `replication.repairBatchDelayMs`; this delay and `replication.repairProbeConcurrency` control peer load, while `repairSchedule` controls when a new completed cycle is refreshed. Set `health.repairMaxAgeMs` longer than the largest expected full-cycle duration plus the schedule interval. An incomplete or backlogged cycle intentionally keeps health degraded.
 
 ### Get legacy client node information
 

--- a/config.default.json5
+++ b/config.default.json5
@@ -15,6 +15,8 @@
   ],
   storeFolder: '.adm-ipfs',
   logLevel: 'debug',
+  // Production logs are structured JSON. Enable this only for local terminals.
+  prettyLogs: false,
   peerDiscovery: {
     bootstrap: [
       '/ip4/194.163.154.252/tcp/4001/p2p/12D3KooWSUCe86zWfas1Lo1UQzXzquZgS81d1DpPPYAuTNjSyniq', // ipfs1
@@ -95,5 +97,14 @@
     requestTimeoutMs: 30000,
     repairEnabled: true,
     repairSchedule: '0 */30 * * * *'
+  },
+  health: {
+    checkpointIntervalMs: 60000,
+    maxCheckpointAgeMs: 180000,
+    storageMaxAgeMs: 120000,
+    repairMaxAgeMs: 3600000,
+    clockSkewToleranceMs: 10000,
+    peerAttestationTimeoutMs: 5000,
+    requiredPeerCount: 1
   }
 }

--- a/config.default.json5
+++ b/config.default.json5
@@ -36,6 +36,7 @@
   // A transfer may run longer than discovery while chunks keep arriving.
   downloadIdleTimeout: 20000,
   downloadMinBytesPerSecond: 32768,
+  downloadMaxDurationMs: 14400000, // 4 h absolute ceiling for one response
   cors: {
     // Exact origins and left-most subdomain wildcards are supported.
     allowedOrigins: [
@@ -64,6 +65,7 @@
   storage: {
     maxRequestSizeBytes: 536870912, // 512 MiB. Combined size of all files in one request
     maxConcurrentUploads: 32, // Uploads writing into the blockstore at the same time; over this, 429
+    maxConcurrentDownloads: 64, // Downloads holding a socket and UnixFS iterator; over this, 429
     diskReserveBytes: 5368709120, // 5 GiB of free space uploads must never consume
     // true keeps an upload temporary until POST /api/file/:cid/confirm.
     // Enabling it is a protocol change: clients must perform that call.
@@ -101,7 +103,8 @@
     repairEnabled: true,
     repairSchedule: '0 */30 * * * *',
     // Bounded passes continue until a complete repair cycle is recorded.
-    repairBatchDelayMs: 1000
+    repairBatchDelayMs: 1000,
+    repairProbeConcurrency: 4
   },
   health: {
     checkpointIntervalMs: 60000,

--- a/config.default.json5
+++ b/config.default.json5
@@ -66,6 +66,8 @@
     maxRequestSizeBytes: 536870912, // 512 MiB. Combined size of all files in one request
     maxConcurrentUploads: 32, // Uploads writing into the blockstore at the same time; over this, 429
     maxConcurrentDownloads: 64, // Downloads holding a socket and UnixFS iterator; over this, 429
+    // Share of the above one client address may hold, so nobody can take every slot
+    maxConcurrentDownloadsPerClient: 8,
     diskReserveBytes: 5368709120, // 5 GiB of free space uploads must never consume
     // true keeps an upload temporary until POST /api/file/:cid/confirm.
     // Enabling it is a protocol change: clients must perform that call.

--- a/config.default.json5
+++ b/config.default.json5
@@ -33,6 +33,9 @@
   uploadLimitSizeBytes: 268435456, // 256 Mb.
   maxFileCount: 10,
   findFileTimeout: 20000,
+  // A transfer may run longer than discovery while chunks keep arriving.
+  downloadIdleTimeout: 20000,
+  downloadMinBytesPerSecond: 32768,
   cors: {
     // Exact origins and left-most subdomain wildcards are supported.
     allowedOrigins: [
@@ -96,7 +99,9 @@
     requireQuorumOnUpload: false, // Incompatible with confirmationRequired; needs ackQuorum >= 2
     requestTimeoutMs: 30000,
     repairEnabled: true,
-    repairSchedule: '0 */30 * * * *'
+    repairSchedule: '0 */30 * * * *',
+    // Bounded passes continue until a complete repair cycle is recorded.
+    repairBatchDelayMs: 1000
   },
   health: {
     checkpointIntervalMs: 60000,

--- a/config.test.json5
+++ b/config.test.json5
@@ -4,6 +4,7 @@
   nodes: [],
   storeFolder: '.adm-ipfs-test',
   logLevel: 'silent',
+  prettyLogs: false,
   peerDiscovery: {
     bootstrap: [],
     // Port 0 lets the OS pick a free port so tests never clash with a running node
@@ -50,5 +51,14 @@
     requestTimeoutMs: 5000,
     repairEnabled: false,
     repairSchedule: '0 */30 * * * *'
+  },
+  health: {
+    checkpointIntervalMs: 1000,
+    maxCheckpointAgeMs: 3000,
+    storageMaxAgeMs: 2000,
+    repairMaxAgeMs: 5000,
+    clockSkewToleranceMs: 100,
+    peerAttestationTimeoutMs: 100,
+    requiredPeerCount: 0
   }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,239 @@
+openapi: 3.1.0
+info:
+  title: ADAMANT IPFS Node API
+  version: 0.1.0
+  description: >-
+    Stable client, lifecycle, and node-health contract. Low-level Helia,
+    libp2p, and optional debug operator routes are intentionally excluded.
+servers:
+  - url: https://ipfs.example.org
+paths:
+  /api/node/health:
+    get:
+      summary: Read the network-aware node checkpoint
+      responses:
+        '200':
+          description: The current state; inspect status because this route is always 200
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+  /api/node/info:
+    get:
+      summary: Read sanitized legacy PWA and iOS node information
+      responses:
+        '200':
+          description: Legacy node information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegacyNodeInfo'
+  /api/node/details:
+    get:
+      summary: Read detailed operator state
+      security:
+        - AdminApiKey: []
+      responses:
+        '200':
+          description: Node identity, storage, health, and bounded HTTP metrics
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/AdminNotConfigured'
+  /api/file/upload:
+    post:
+      summary: Upload one or more files
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [files]
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        '200':
+          description: Files were stored and pinned
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '413':
+          description: Request or file limit exceeded
+        '429':
+          description: Upload rate or concurrency limit exceeded
+        '503':
+          description: Required replication quorum was not reached
+        '507':
+          description: The disk reserve would be consumed
+  /api/file/{cid}:
+    parameters:
+      - $ref: '#/components/parameters/Cid'
+    get:
+      summary: Download a complete immutable file
+      responses:
+        '200':
+          description: Complete file attachment
+          headers:
+            ETag:
+              schema: { type: string }
+            Cache-Control:
+              schema: { type: string }
+            Accept-Ranges:
+              schema: { type: string, const: none }
+          content:
+            application/octet-stream:
+              schema: { type: string, format: binary }
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '408':
+          description: Discovery or complete retrieval timed out
+        '416':
+          description: Range requests are not supported
+        '429':
+          description: Read rate limit exceeded
+  /api/file/{cid}/status:
+    parameters:
+      - $ref: '#/components/parameters/Cid'
+    get:
+      summary: Read public lifecycle and replication counts
+      responses:
+        '200': { description: File lifecycle state }
+        '404': { description: Unknown CID }
+  /api/file/{cid}/confirm:
+    parameters:
+      - $ref: '#/components/parameters/Cid'
+    post:
+      summary: Promote a temporary file to durable storage
+      security:
+        - AdminApiKey: []
+      responses:
+        '200': { description: File confirmed }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { description: Unknown CID }
+  /api/file/{cid}/unpin:
+    parameters:
+      - $ref: '#/components/parameters/Cid'
+    post:
+      summary: Release durable content
+      security:
+        - AdminApiKey: []
+      responses:
+        '200': { description: File released for later collection }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { description: Unknown CID }
+  /api/storage/metrics:
+    get:
+      summary: Read public bounded storage and replication counts
+      responses:
+        '200': { description: Cached storage metrics }
+  /api/storage/policy:
+    get:
+      summary: Read upload, lifecycle, and durability policy
+      responses:
+        '200': { description: Public storage policy }
+  /api/storage/gc:
+    post:
+      summary: Run or preview garbage collection
+      security:
+        - AdminApiKey: []
+      parameters:
+        - name: dryRun
+          in: query
+          schema: { type: boolean, default: false }
+      responses:
+        '200': { description: Garbage collection report }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '409': { description: Garbage collection is already running }
+  /api/storage/repair:
+    post:
+      summary: Run the next bounded replication repair batch
+      security:
+        - AdminApiKey: []
+      responses:
+        '200': { description: Repair batch and cycle progress }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '409': { description: Replication repair is already running }
+components:
+  securitySchemes:
+    AdminApiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+  parameters:
+    Cid:
+      name: cid
+      in: path
+      required: true
+      schema: { type: string }
+  schemas:
+    Health:
+      type: object
+      required:
+        - status
+        - height
+        - timestamp
+        - checkpointIntervalMs
+        - membershipVersion
+        - checks
+        - peerAttestations
+      properties:
+        status:
+          type: string
+          enum: [starting, ready, stale, degraded]
+        height:
+          type: integer
+          minimum: 0
+          description: Persisted Unix milliseconds at the start of the last valid fixed round
+        timestamp: { type: integer }
+        checkpointIntervalMs: { type: integer, minimum: 1000 }
+        membershipVersion: { type: string, pattern: '^[a-f0-9]{64}$' }
+        checks:
+          type: object
+          additionalProperties: { type: boolean }
+        peerAttestations:
+          type: object
+          required: [required, received]
+          properties:
+            required: { type: integer, minimum: 0 }
+            received: { type: integer, minimum: 0 }
+    LegacyNodeInfo:
+      type: object
+      required:
+        - version
+        - timestamp
+        - heliaStatus
+        - blockstoreSizeMb
+        - datastoreSizeMb
+        - availableSizeInMb
+      properties:
+        version: { type: string }
+        timestamp: { type: integer }
+        heliaStatus: { type: string }
+        blockstoreSizeMb: { type: number }
+        datastoreSizeMb: { type: number }
+        availableSizeInMb: { type: number }
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error: { type: string }
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    Unauthorized:
+      description: Administrative API key is missing or invalid
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    AdminNotConfigured:
+      description: Administrative API key is not configured
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -264,6 +264,7 @@ components:
       required:
         - requests
         - responses
+        - aborted
         - inFlight
         - totalResponseTimeMs
         - maxResponseTimeMs
@@ -278,6 +279,10 @@ components:
             3xx: { type: integer, minimum: 0 }
             4xx: { type: integer, minimum: 0 }
             5xx: { type: integer, minimum: 0 }
+        aborted:
+          type: integer
+          minimum: 0
+          description: Responses whose connection closed before the body finished, counted apart from the status families
         inFlight: { type: integer, minimum: 0 }
         totalResponseTimeMs: { type: number, minimum: 0 }
         maxResponseTimeMs: { type: number, minimum: 0 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -173,15 +173,21 @@ components:
     Health:
       type: object
       required:
-        - status
+        - version
+        - uptimeMs
+        - state
         - height
         - timestamp
-        - checkpointIntervalMs
-        - membershipVersion
+        - checkpoint
+        - membership
+        - startup
+        - storage
+        - replication
         - checks
-        - peerAttestations
       properties:
-        status:
+        version: { type: string }
+        uptimeMs: { type: integer, minimum: 0 }
+        state:
           type: string
           enum: [starting, ready, stale, degraded]
         height:
@@ -189,17 +195,46 @@ components:
           minimum: 0
           description: Persisted Unix milliseconds at the start of the last valid fixed round
         timestamp: { type: integer }
-        checkpointIntervalMs: { type: integer, minimum: 1000 }
-        membershipVersion: { type: string, pattern: '^[a-f0-9]{64}$' }
+        checkpoint:
+          type: object
+          required: [intervalMs, observedAt, ageMs, maxAgeMs]
+          properties:
+            intervalMs: { type: integer, minimum: 1000 }
+            observedAt: { type: [integer, 'null'] }
+            ageMs: { type: [integer, 'null'], minimum: 0 }
+            maxAgeMs: { type: integer, minimum: 1000 }
+        membership:
+          type: object
+          required: [version, requiredPeers, attestedPeers]
+          properties:
+            version: { type: string, pattern: '^[a-f0-9]{64}$' }
+            requiredPeers: { type: integer, minimum: 0 }
+            attestedPeers: { type: integer, minimum: 0 }
+        startup:
+          type: object
+          required: [complete, healthy]
+          properties:
+            complete: { type: boolean }
+            healthy: { type: boolean }
+        storage:
+          type: object
+          required: [measuredAt, measurementAgeMs, availableBytes, reservedBytes]
+          properties:
+            measuredAt: { type: [integer, 'null'] }
+            measurementAgeMs: { type: [integer, 'null'], minimum: 0 }
+            availableBytes: { type: integer, minimum: 0 }
+            reservedBytes: { type: integer, minimum: 0 }
+        replication:
+          type: object
+          required: [repairRequired, lastCompleteAt, ageMs, backlog]
+          properties:
+            repairRequired: { type: boolean }
+            lastCompleteAt: { type: [integer, 'null'] }
+            ageMs: { type: [integer, 'null'], minimum: 0 }
+            backlog: { type: integer, minimum: 0 }
         checks:
           type: object
           additionalProperties: { type: boolean }
-        peerAttestations:
-          type: object
-          required: [required, received]
-          properties:
-            required: { type: integer, minimum: 0 }
-            received: { type: integer, minimum: 0 }
     LegacyNodeInfo:
       type: object
       required:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -36,6 +36,10 @@ paths:
       responses:
         '200':
           description: Node identity, storage, health, and bounded HTTP metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeDetails'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '503':
@@ -73,7 +77,8 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Cid'
     get:
-      summary: Download a complete immutable file
+      summary: Download a complete content-addressed file
+      description: Range headers are ignored and return the complete 200 representation
       responses:
         '200':
           description: Complete file attachment
@@ -87,12 +92,12 @@ paths:
           content:
             application/octet-stream:
               schema: { type: string, format: binary }
+        '304':
+          description: The validated CID representation has not changed
         '400':
           $ref: '#/components/responses/BadRequest'
         '408':
           description: Discovery or complete retrieval timed out
-        '416':
-          description: Range requests are not supported
         '429':
           description: Read rate limit exceeded
   /api/file/{cid}/status:
@@ -207,7 +212,10 @@ components:
           type: object
           required: [version, requiredPeers, attestedPeers]
           properties:
-            version: { type: string, pattern: '^[a-f0-9]{64}$' }
+            version:
+              type: string
+              pattern: '^[a-f0-9]{64}$'
+              description: Peer-set epoch; compare checkpoint heights only when versions match
             requiredPeers: { type: integer, minimum: 0 }
             attestedPeers: { type: integer, minimum: 0 }
         startup:
@@ -218,12 +226,11 @@ components:
             healthy: { type: boolean }
         storage:
           type: object
-          required: [measuredAt, measurementAgeMs, availableBytes, reservedBytes]
+          required: [measuredAt, measurementAgeMs, reserveHealthy]
           properties:
             measuredAt: { type: [integer, 'null'] }
             measurementAgeMs: { type: [integer, 'null'], minimum: 0 }
-            availableBytes: { type: integer, minimum: 0 }
-            reservedBytes: { type: integer, minimum: 0 }
+            reserveHealthy: { type: boolean }
         replication:
           type: object
           required: [repairRequired, lastCompleteAt, ageMs, backlog]
@@ -235,6 +242,63 @@ components:
         checks:
           type: object
           additionalProperties: { type: boolean }
+    HttpMetrics:
+      type: object
+      required:
+        - requests
+        - responses
+        - inFlight
+        - totalResponseTimeMs
+        - maxResponseTimeMs
+        - averageResponseTimeMs
+      properties:
+        requests: { type: integer, minimum: 0 }
+        responses:
+          type: object
+          required: [2xx, 3xx, 4xx, 5xx]
+          properties:
+            2xx: { type: integer, minimum: 0 }
+            3xx: { type: integer, minimum: 0 }
+            4xx: { type: integer, minimum: 0 }
+            5xx: { type: integer, minimum: 0 }
+        inFlight: { type: integer, minimum: 0 }
+        totalResponseTimeMs: { type: number, minimum: 0 }
+        maxResponseTimeMs: { type: number, minimum: 0 }
+        averageResponseTimeMs: { type: number, minimum: 0 }
+    NodeDetails:
+      type: object
+      required:
+        - version
+        - timestamp
+        - heliaStatus
+        - peerId
+        - multiAddresses
+        - blockstoreSizeMb
+        - datastoreSizeMb
+        - availableSizeInMb
+        - pinnedBytes
+        - reclaimableBytes
+        - availableBytes
+        - reservedBytes
+        - health
+        - http
+      properties:
+        version: { type: string }
+        timestamp: { type: integer }
+        heliaStatus: { type: string }
+        peerId: { type: string }
+        multiAddresses:
+          type: array
+          items: { type: string }
+        blockstoreSizeMb: { type: number }
+        datastoreSizeMb: { type: number }
+        availableSizeInMb: { type: number }
+        pinnedBytes: { type: integer, minimum: 0 }
+        reclaimableBytes: { type: integer, minimum: 0 }
+        availableBytes: { type: integer, minimum: 0 }
+        reservedBytes: { type: integer, minimum: 0 }
+        health: { $ref: '#/components/schemas/Health' }
+        http: { $ref: '#/components/schemas/HttpMetrics' }
     LegacyNodeInfo:
       type: object
       required:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -99,7 +99,7 @@ paths:
         '408':
           description: Discovery or complete retrieval timed out
         '429':
-          description: Read rate limit exceeded
+          description: Read rate or global download concurrency limit exceeded
   /api/file/{cid}/status:
     parameters:
       - $ref: '#/components/parameters/Cid'
@@ -195,6 +195,7 @@ components:
         state:
           type: string
           enum: [starting, ready, stale, degraded]
+          description: Stale only after checkpoint age exceeds maxAgeMs; the exact limit is valid
         height:
           type: integer
           minimum: 0
@@ -210,6 +211,7 @@ components:
             maxAgeMs: { type: integer, minimum: 1000 }
         membership:
           type: object
+          description: Peer evidence captured when checkpoint.observedAt was evaluated
           required: [version, requiredPeers, attestedPeers]
           properties:
             version:
@@ -220,6 +222,7 @@ components:
             attestedPeers: { type: integer, minimum: 0 }
         startup:
           type: object
+          description: Startup evidence captured when checkpoint.observedAt was evaluated
           required: [complete, healthy]
           properties:
             complete: { type: boolean }
@@ -241,6 +244,7 @@ components:
             backlog: { type: integer, minimum: 0 }
         checks:
           type: object
+          description: Storage and repair freshness are updated at read time; other checks describe checkpoint.observedAt
           additionalProperties: { type: boolean }
     HttpMetrics:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13,7 +13,7 @@ paths:
       summary: Read the network-aware node checkpoint
       responses:
         '200':
-          description: The current state; inspect status because this route is always 200
+          description: The current state; inspect the state field because this route is always 200
           content:
             application/json:
               schema:
@@ -183,6 +183,7 @@ components:
         - state
         - height
         - timestamp
+        - evaluatedAt
         - checkpoint
         - membership
         - startup
@@ -206,7 +207,12 @@ components:
             Persisted Unix milliseconds at the start of the last valid fixed round.
             Peers may attest an adjacent round across a boundary, so two healthy
             nodes can report heights one intervalMs apart at a round change
-        timestamp: { type: integer }
+        timestamp: { type: integer, description: When this response was produced }
+        evaluatedAt:
+          type: integer
+          description: >-
+            When the checkpoint attempt behind this snapshot ran; membership,
+            startup, and the non-age checks are dated by this, not by checkpoint.observedAt
         checkpoint:
           type: object
           required: [intervalMs, observedAt, ageMs, maxAgeMs]
@@ -217,7 +223,7 @@ components:
             maxAgeMs: { type: integer, minimum: 1000 }
         membership:
           type: object
-          description: Peer evidence captured when checkpoint.observedAt was evaluated
+          description: Peer evidence from the attempt at evaluatedAt, which may be a failed one
           required: [version, requiredPeers, attestedPeers]
           properties:
             version:
@@ -228,7 +234,7 @@ components:
             attestedPeers: { type: integer, minimum: 0 }
         startup:
           type: object
-          description: Startup evidence captured when checkpoint.observedAt was evaluated
+          description: Startup evidence from the attempt at evaluatedAt, which may be a failed one
           required: [complete, healthy]
           properties:
             complete: { type: boolean }
@@ -250,7 +256,7 @@ components:
             backlog: { type: integer, minimum: 0 }
         checks:
           type: object
-          description: Checkpoint, storage, and repair freshness are recomputed at read time; every other check describes checkpoint.observedAt
+          description: Checkpoint, storage, and repair freshness are recomputed at read time; every other check describes evaluatedAt
           additionalProperties: { type: boolean }
     HttpMetrics:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -99,7 +99,7 @@ paths:
         '408':
           description: Discovery or complete retrieval timed out
         '429':
-          description: Read rate or global download concurrency limit exceeded
+          description: Read rate, per-client, or global download concurrency limit exceeded
   /api/file/{cid}/status:
     parameters:
       - $ref: '#/components/parameters/Cid'
@@ -195,11 +195,17 @@ components:
         state:
           type: string
           enum: [starting, ready, stale, degraded]
-          description: Stale only after checkpoint age exceeds maxAgeMs; the exact limit is valid
+          description: >-
+            Downgrades happen at read time; recovery to ready needs a successful
+            checkpoint, so expect up to checkpoint.intervalMs of lag. Stale only
+            after checkpoint age exceeds maxAgeMs; the exact limit is valid
         height:
           type: integer
           minimum: 0
-          description: Persisted Unix milliseconds at the start of the last valid fixed round
+          description: >-
+            Persisted Unix milliseconds at the start of the last valid fixed round.
+            Peers may attest an adjacent round across a boundary, so two healthy
+            nodes can report heights one intervalMs apart at a round change
         timestamp: { type: integer }
         checkpoint:
           type: object
@@ -244,10 +250,11 @@ components:
             backlog: { type: integer, minimum: 0 }
         checks:
           type: object
-          description: Storage and repair freshness are updated at read time; other checks describe checkpoint.observedAt
+          description: Checkpoint, storage, and repair freshness are recomputed at read time; every other check describes checkpoint.observedAt
           additionalProperties: { type: boolean }
     HttpMetrics:
       type: object
+      description: Counters accumulated since process start, not a sliding window
       required:
         - requests
         - responses
@@ -286,6 +293,7 @@ components:
         - reservedBytes
         - health
         - http
+        - concurrency
       properties:
         version: { type: string }
         timestamp: { type: integer }
@@ -303,6 +311,31 @@ components:
         reservedBytes: { type: integer, minimum: 0 }
         health: { $ref: '#/components/schemas/Health' }
         http: { $ref: '#/components/schemas/HttpMetrics' }
+        concurrency: { $ref: '#/components/schemas/ConcurrencyMetrics' }
+    ConcurrencyMetrics:
+      type: object
+      description: Admission-limiter occupancy, so a capacity 429 is distinguishable from a rate-limit 429
+      required: [uploads, incomingCopies, downloads]
+      properties:
+        uploads:
+          type: object
+          required: [active, limit]
+          properties:
+            active: { type: integer, minimum: 0 }
+            limit: { type: integer, minimum: 1 }
+        incomingCopies:
+          type: object
+          required: [active, limit]
+          properties:
+            active: { type: integer, minimum: 0 }
+            limit: { type: integer, minimum: 1 }
+        downloads:
+          type: object
+          required: [active, limit, perClientLimit]
+          properties:
+            active: { type: integer, minimum: 0 }
+            limit: { type: integer, minimum: 1 }
+            perClientLimit: { type: integer, minimum: 1 }
     LegacyNodeInfo:
       type: object
       required:

--- a/docs/storage-lifecycle.md
+++ b/docs/storage-lifecycle.md
@@ -458,7 +458,7 @@ The repair job (`replication.repairSchedule`, or `POST /api/storage/repair`)
 lists confirmed files this node holds whose designated peers have not all
 acknowledged, and places the missing copies again.
 
-Each scheduled pass remains bounded to 50 held files. Its sorted cursor and
+Each scheduled pass remains bounded to 50 confirmed records. Its sorted cursor and
 aggregate result are persisted under the node datastore, so restart resumes the
 same cycle. A repair checkpoint is recorded only after a pass reaches the end
 of the candidate set; a pass over one batch is not presented as full-fleet

--- a/docs/storage-lifecycle.md
+++ b/docs/storage-lifecycle.md
@@ -13,13 +13,14 @@ default, so a configuration file written before this feature keeps working. See
 An upload is refused before a single block reaches the blockstore when any of
 these limits is exceeded.
 
-| Limit                  | Option                         | Response |
-| ---------------------- | ------------------------------ | -------- |
-| Concurrent uploads     | `storage.maxConcurrentUploads` | `429`    |
-| Aggregate request size | `storage.maxRequestSizeBytes`  | `413`    |
-| Disk reserve           | `storage.diskReserveBytes`     | `507`    |
-| Files per request      | `maxFileCount`                 | `400`    |
-| Single file size       | `uploadLimitSizeBytes`         | `400`    |
+| Limit                  | Option                           | Response |
+| ---------------------- | -------------------------------- | -------- |
+| Concurrent uploads     | `storage.maxConcurrentUploads`   | `429`    |
+| Concurrent downloads   | `storage.maxConcurrentDownloads` | `429`    |
+| Aggregate request size | `storage.maxRequestSizeBytes`    | `413`    |
+| Disk reserve           | `storage.diskReserveBytes`       | `507`    |
+| Files per request      | `maxFileCount`                   | `400`    |
+| Single file size       | `uploadLimitSizeBytes`           | `400`    |
 
 The first three are checked by the upload guard before the multipart parser
 runs. The last two are enforced by the parser itself through
@@ -458,7 +459,9 @@ The repair job (`replication.repairSchedule`, or `POST /api/storage/repair`)
 lists confirmed files this node holds whose designated peers have not all
 acknowledged, and places the missing copies again.
 
-Each scheduled pass remains bounded to 50 confirmed records. Its sorted cursor and
+Each scheduled pass remains bounded to 50 confirmed records shared by local-holder
+repair and released-record rescue. The inter-pass delay and probe concurrency
+bound sustained peer load. Its sorted cursor and
 aggregate result are persisted under the node datastore, so restart resumes the
 same cycle. A repair checkpoint is recorded only after a pass reaches the end
 of the candidate set; a pass over one batch is not presented as full-fleet

--- a/docs/storage-lifecycle.md
+++ b/docs/storage-lifecycle.md
@@ -458,6 +458,13 @@ The repair job (`replication.repairSchedule`, or `POST /api/storage/repair`)
 lists confirmed files this node holds whose designated peers have not all
 acknowledged, and places the missing copies again.
 
+Each scheduled pass remains bounded to 50 held files. Its sorted cursor and
+aggregate result are persisted under the node datastore, so restart resumes the
+same cycle. A repair checkpoint is recorded only after a pass reaches the end
+of the candidate set; a pass over one batch is not presented as full-fleet
+evidence. A cycle containing an unresolved shortfall is complete but unhealthy,
+and therefore cannot advance the node health checkpoint.
+
 Replication needs the peers to be connected over libp2p, because the copy itself
 travels by bitswap. Startup peering opens those connections before the API
 starts serving, so the first upload after a restart already has somewhere to
@@ -536,8 +543,9 @@ A collection report also lists `demoted`: files whose local copy was handed over
 to their designated holders during that pass.
 
 Values are refreshed on the `diskUsageScanPeriod` schedule, because a directory
-scan and a full registry sweep are too expensive for a request path. A subset is
-also included in `GET /api/node/info`.
+scan and a full registry sweep are too expensive for a request path. A legacy
+megabyte subset is included in public `GET /api/node/info`; detailed byte values
+are included in authenticated `GET /api/node/details`.
 
 ## Recovery and rollback
 

--- a/docs/storage-lifecycle.md
+++ b/docs/storage-lifecycle.md
@@ -479,9 +479,15 @@ bound sustained peer load. Its sorted cursor and
 aggregate result are persisted under the node datastore, so restart resumes the
 same cycle. A repair checkpoint is recorded only after a pass reaches the end
 of the candidate set; a pass over one batch is not presented as full-fleet
-evidence. A completed cycle covers the records that were confirmed when it
-began: content admitted mid-cycle is placed by the upload path and verified by
-the next cycle. A cycle containing an unresolved shortfall is complete but unhealthy,
+evidence.
+
+A cycle commits to a candidate list read once at its start, so the registry is
+scanned per cycle rather than per pass. One more scan at the end names records
+admitted while the cycle was walking; those are appended and covered by the same
+cycle, for a bounded number of catch-up rounds. A cycle that runs out of rounds
+still finishes and hands its cursor back, but it is not published as durability
+evidence: the last cycle that covered its whole set keeps that role, so
+readiness ages out on its own schedule instead of advancing on a coverage gap. A cycle containing an unresolved shortfall is complete but unhealthy,
 and therefore cannot advance the node health checkpoint.
 
 Replication needs the peers to be connected over libp2p, because the copy itself

--- a/docs/storage-lifecycle.md
+++ b/docs/storage-lifecycle.md
@@ -487,7 +487,12 @@ admitted while the cycle was walking; those are appended and covered by the same
 cycle, for a bounded number of catch-up rounds. A cycle that runs out of rounds
 still finishes and hands its cursor back, but it is not published as durability
 evidence: the last cycle that covered its whole set keeps that role, so
-readiness ages out on its own schedule instead of advancing on a coverage gap. A cycle containing an unresolved shortfall is complete but unhealthy,
+readiness ages out on its own schedule instead of advancing on a coverage gap.
+
+A restart resumes the cycle from its persisted cursor, but the rebuilt list
+cannot tell a record admitted during the downtime from one the lost passes
+already visited. Such a cycle finishes without claiming coverage, and the cycle
+after it publishes again. A cycle containing an unresolved shortfall is complete but unhealthy,
 and therefore cannot advance the node health checkpoint.
 
 Replication needs the peers to be connected over libp2p, because the copy itself

--- a/docs/storage-lifecycle.md
+++ b/docs/storage-lifecycle.md
@@ -13,19 +13,33 @@ default, so a configuration file written before this feature keeps working. See
 An upload is refused before a single block reaches the blockstore when any of
 these limits is exceeded.
 
-| Limit                  | Option                           | Response |
-| ---------------------- | -------------------------------- | -------- |
-| Concurrent uploads     | `storage.maxConcurrentUploads`   | `429`    |
-| Concurrent downloads   | `storage.maxConcurrentDownloads` | `429`    |
-| Aggregate request size | `storage.maxRequestSizeBytes`    | `413`    |
-| Disk reserve           | `storage.diskReserveBytes`       | `507`    |
-| Files per request      | `maxFileCount`                   | `400`    |
-| Single file size       | `uploadLimitSizeBytes`           | `400`    |
+| Limit                  | Option                         | Response |
+| ---------------------- | ------------------------------ | -------- |
+| Concurrent uploads     | `storage.maxConcurrentUploads` | `429`    |
+| Aggregate request size | `storage.maxRequestSizeBytes`  | `413`    |
+| Disk reserve           | `storage.diskReserveBytes`     | `507`    |
+| Files per request      | `maxFileCount`                 | `400`    |
+| Single file size       | `uploadLimitSizeBytes`         | `400`    |
 
 The first three are checked by the upload guard before the multipart parser
 runs. The last two are enforced by the parser itself through
 `createMultipartLimits`, which aborts the request before handing an over-limit
 part to the storage engine.
+
+## Download admission
+
+Retrieval has its own guard on `GET /api/file/:cid`, checked before the handler
+runs rather than by the upload guard above.
+
+| Limit                          | Option                                    | Response |
+| ------------------------------ | ----------------------------------------- | -------- |
+| Concurrent downloads, node     | `storage.maxConcurrentDownloads`          | `429`    |
+| Concurrent downloads, a client | `storage.maxConcurrentDownloadsPerClient` | `429`    |
+
+The per-client share is checked first, so an address already at its limit is
+refused without consuming a node slot. A slot is held for the whole response,
+which is why the global bound alone would let one address occupy every one of
+them for the length of its transfers.
 
 The aggregate size is checked twice: against `Content-Length` before parsing,
 and against the bytes actually streamed, because a chunked request declares no
@@ -465,7 +479,9 @@ bound sustained peer load. Its sorted cursor and
 aggregate result are persisted under the node datastore, so restart resumes the
 same cycle. A repair checkpoint is recorded only after a pass reaches the end
 of the candidate set; a pass over one batch is not presented as full-fleet
-evidence. A cycle containing an unresolved shortfall is complete but unhealthy,
+evidence. A completed cycle covers the records that were confirmed when it
+began: content admitted mid-cycle is placed by the upload path and verified by
+the next cycle. A cycle containing an unresolved shortfall is complete but unhealthy,
 and therefore cannot advance the node health checkpoint.
 
 Replication needs the peers to be connected over libp2p, because the copy itself

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:build": "rimraf dist-test && tsc -p tsconfig.test.json",
     "test": "npm run test:build && npm run test:unit && npm run test:integration",
     "test:unit": "IPFS_NODE_CONFIG=test node --test \"dist-test/test/*.test.js\"",

--- a/src/api/file.ts
+++ b/src/api/file.ts
@@ -96,23 +96,36 @@ router.get('/:cid/status', readLimiter, async (req, res, next) => {
 })
 
 router.get('/:cid', readLimiter, async (req, res, next) => {
+  const requestController = new AbortController()
+  res.once('close', () => {
+    if (!res.writableEnded) {
+      requestController.abort(new Error('Download client disconnected'))
+    }
+  })
+
   try {
+    if (req.headers.range !== undefined) {
+      res.set('Accept-Ranges', 'none')
+      return res.status(416).send({ error: 'Range requests are not supported' })
+    }
+
     const cid = parseCid(req.params.cid)
 
     // Reach the file's holders first. Without this the read only succeeds if a
     // peer that has the file is already connected, which stops being true as
     // soon as the network is larger than the connection limit.
-    await prepareFileRetrieval(cid)
+    await prepareFileRetrieval(cid, requestController.signal)
 
-    const fileStats = await getFileStats(cid)
-    const stream = downloadFile(cid)
+    const fileStats = await getFileStats(cid, requestController.signal)
+    const download = downloadFile(cid, { signal: requestController.signal })
 
     sendDownloadStream(
-      stream,
+      download.stream,
       res,
       { cid: cid.toString(), fileSize: fileStats.size },
       next,
-      (error) => logger.error(error)
+      (error) => logger.error(error),
+      () => download.abort(new Error('Download client disconnected'))
     )
   } catch (error) {
     next(error)

--- a/src/api/file.ts
+++ b/src/api/file.ts
@@ -16,7 +16,11 @@ import {
 import { fileRegistry } from '../storage/state.js'
 import { createUploadHandler } from './uploadRoute.js'
 import { parseCid } from '../utils/cid.js'
-import { sendDownloadStream } from '../utils/downloadResponse.js'
+import {
+  matchesDownloadEtag,
+  sendDownloadStream,
+  setDownloadHeaders
+} from '../utils/downloadResponse.js'
 import { downloadFile, getFileStats } from '../utils/file.js'
 import { logger } from '../utils/logger.js'
 
@@ -104,11 +108,6 @@ router.get('/:cid', readLimiter, async (req, res, next) => {
   })
 
   try {
-    if (req.headers.range !== undefined) {
-      res.set('Accept-Ranges', 'none')
-      return res.status(416).send({ error: 'Range requests are not supported' })
-    }
-
     const cid = parseCid(req.params.cid)
 
     // Reach the file's holders first. Without this the read only succeeds if a
@@ -117,17 +116,29 @@ router.get('/:cid', readLimiter, async (req, res, next) => {
     await prepareFileRetrieval(cid, requestController.signal)
 
     const fileStats = await getFileStats(cid, requestController.signal)
-    const download = downloadFile(cid, { signal: requestController.signal })
+    const metadata = { cid: cid.toString(), fileSize: fileStats.size }
+
+    // Range is deliberately ignored and the complete representation is sent.
+    // This preserves established PWA/iOS behavior without advertising ranges.
+    if (matchesDownloadEtag(req.headers['if-none-match'], metadata.cid)) {
+      setDownloadHeaders(res, metadata)
+      res.removeHeader('Content-Length')
+      res.removeHeader('Content-Disposition')
+      return res.status(304).end()
+    }
+
+    const download = downloadFile(cid, fileStats.size, { signal: requestController.signal })
 
     sendDownloadStream(
       download.stream,
       res,
-      { cid: cid.toString(), fileSize: fileStats.size },
+      metadata,
       next,
       (error) => logger.error(error),
       () => download.abort(new Error('Download client disconnected'))
     )
   } catch (error) {
+    if (requestController.signal.aborted || res.destroyed) return
     next(error)
   }
 })

--- a/src/api/file.ts
+++ b/src/api/file.ts
@@ -3,6 +3,7 @@ import { config } from '../config.js'
 import { helia } from '../helia.js'
 import { admitUpload, getUploadSession } from '../middleware/uploadGuards.js'
 import { readLimiter, uploadLimiter } from '../middleware/rateLimiter.js'
+import { admitDownload } from '../middleware/downloadGuards.js'
 import { multerStorage } from '../multer.js'
 import {
   abortUploadedReplicas,
@@ -99,7 +100,7 @@ router.get('/:cid/status', readLimiter, async (req, res, next) => {
   }
 })
 
-router.get('/:cid', readLimiter, async (req, res, next) => {
+router.get('/:cid', readLimiter, admitDownload, async (req, res, next) => {
   const requestController = new AbortController()
   res.once('close', () => {
     if (!res.writableEnded) {

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -2,6 +2,7 @@ import { packageJson } from '../config.js'
 import { getDiskUsageStats } from '../disk-usage.cron.js'
 import { helia } from '../helia.js'
 import { getStorageMetrics } from '../storage/metrics.js'
+import { getConcurrencyMetrics } from '../storage/state.js'
 import { getHealthSnapshot } from '../health/service.js'
 import { getHttpMetrics } from '../observability.js'
 import { readLimiter } from '../middleware/rateLimiter.js'
@@ -18,7 +19,8 @@ const routers = createNodeRouters({
   getDiskUsageStats,
   getStorageMetrics,
   getHealthSnapshot,
-  getHttpMetrics
+  getHttpMetrics,
+  getConcurrencyMetrics
 })
 
 export const publicNodeRouter = routers.publicNodeRouter

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -11,7 +11,11 @@ const router = Router()
 
 publicNodeRouter.get('/health', async (req, res, next) => {
   try {
-    res.status(200).send(getHealthSnapshot())
+    res.status(200).send({
+      version: packageJson.version,
+      uptimeMs: Math.floor(process.uptime() * 1000),
+      ...getHealthSnapshot()
+    })
   } catch (err) {
     next(err)
   }

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -3,22 +3,39 @@ import { packageJson } from '../config.js'
 import { getDiskUsageStats } from '../disk-usage.cron.js'
 import { helia } from '../helia.js'
 import { getStorageMetrics } from '../storage/metrics.js'
+import { getHealthSnapshot } from '../health/service.js'
+import { getHttpMetrics } from '../observability.js'
 
 export const publicNodeRouter = Router()
 const router = Router()
 
 publicNodeRouter.get('/health', async (req, res, next) => {
   try {
+    res.status(200).send(getHealthSnapshot())
+  } catch (err) {
+    next(err)
+  }
+})
+
+/** Legacy PWA/iOS contract. Keep public and free of node identity or operator data. */
+publicNodeRouter.get('/info', async (req, res, next) => {
+  try {
+    const { blockstoreSizeMb, datastoreSizeMb, availableSizeInMb } = getDiskUsageStats()
     res.send({
+      version: packageJson.version,
       timestamp: Date.now(),
-      heliaStatus: helia.libp2p.status
+      heliaStatus: helia.libp2p.status,
+      blockstoreSizeMb,
+      datastoreSizeMb,
+      availableSizeInMb
     })
   } catch (err) {
     next(err)
   }
 })
 
-router.get('/info', async (req, res, next) => {
+/** Detailed node identity and storage report for authenticated operators. */
+router.get('/details', async (req, res, next) => {
   try {
     const { blockstoreSizeMb, datastoreSizeMb, availableSizeInMb } = getDiskUsageStats()
     const storage = getStorageMetrics()
@@ -35,7 +52,9 @@ router.get('/info', async (req, res, next) => {
       pinnedBytes: storage.pinnedBytes,
       reclaimableBytes: storage.reclaimableBytes,
       availableBytes: storage.availableBytes,
-      reservedBytes: storage.reservedBytes
+      reservedBytes: storage.reservedBytes,
+      health: getHealthSnapshot(),
+      http: getHttpMetrics()
     })
   } catch (err) {
     next(err)

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -1,68 +1,25 @@
-import { Router } from 'express'
 import { packageJson } from '../config.js'
 import { getDiskUsageStats } from '../disk-usage.cron.js'
 import { helia } from '../helia.js'
 import { getStorageMetrics } from '../storage/metrics.js'
 import { getHealthSnapshot } from '../health/service.js'
 import { getHttpMetrics } from '../observability.js'
+import { readLimiter } from '../middleware/rateLimiter.js'
+import { createNodeRouters } from './nodeRoutes.js'
 
-export const publicNodeRouter = Router()
-const router = Router()
-
-publicNodeRouter.get('/health', async (req, res, next) => {
-  try {
-    res.status(200).send({
-      version: packageJson.version,
-      uptimeMs: Math.floor(process.uptime() * 1000),
-      ...getHealthSnapshot()
-    })
-  } catch (err) {
-    next(err)
-  }
+const routers = createNodeRouters({
+  version: packageJson.version,
+  now: Date.now,
+  uptimeMs: () => Math.floor(process.uptime() * 1000),
+  readLimiter,
+  getHeliaStatus: () => helia.libp2p.status,
+  getPeerId: () => helia.libp2p.peerId.toString(),
+  getMultiAddresses: () => helia.libp2p.getMultiaddrs().map((address) => address.toString()),
+  getDiskUsageStats,
+  getStorageMetrics,
+  getHealthSnapshot,
+  getHttpMetrics
 })
 
-/** Legacy PWA/iOS contract. Keep public and free of node identity or operator data. */
-publicNodeRouter.get('/info', async (req, res, next) => {
-  try {
-    const { blockstoreSizeMb, datastoreSizeMb, availableSizeInMb } = getDiskUsageStats()
-    res.send({
-      version: packageJson.version,
-      timestamp: Date.now(),
-      heliaStatus: helia.libp2p.status,
-      blockstoreSizeMb,
-      datastoreSizeMb,
-      availableSizeInMb
-    })
-  } catch (err) {
-    next(err)
-  }
-})
-
-/** Detailed node identity and storage report for authenticated operators. */
-router.get('/details', async (req, res, next) => {
-  try {
-    const { blockstoreSizeMb, datastoreSizeMb, availableSizeInMb } = getDiskUsageStats()
-    const storage = getStorageMetrics()
-    res.send({
-      version: packageJson.version,
-      timestamp: Date.now(),
-      heliaStatus: helia.libp2p.status,
-      peerId: helia.libp2p.peerId,
-      multiAddresses: helia.libp2p.getMultiaddrs(),
-      blockstoreSizeMb,
-      datastoreSizeMb,
-      availableSizeInMb,
-      // Byte-accurate figures; GET /api/storage/metrics carries the full report.
-      pinnedBytes: storage.pinnedBytes,
-      reclaimableBytes: storage.reclaimableBytes,
-      availableBytes: storage.availableBytes,
-      reservedBytes: storage.reservedBytes,
-      health: getHealthSnapshot(),
-      http: getHttpMetrics()
-    })
-  } catch (err) {
-    next(err)
-  }
-})
-
-export default router
+export const publicNodeRouter = routers.publicNodeRouter
+export default routers.nodeRouter

--- a/src/api/nodeRoutes.ts
+++ b/src/api/nodeRoutes.ts
@@ -33,8 +33,7 @@ export function createNodeRouters(deps: NodeRouteDependencies): {
   const publicNodeRouter = Router()
   const nodeRouter = Router()
 
-  publicNodeRouter.get('/health', (req, res, next) => {
-    void req
+  publicNodeRouter.get('/health', (_req, res, next) => {
     try {
       res.status(200).send({
         version: deps.version,
@@ -47,8 +46,7 @@ export function createNodeRouters(deps: NodeRouteDependencies): {
   })
 
   /** Legacy PWA/iOS contract. Keep public and free of node identity or operator data. */
-  publicNodeRouter.get('/info', deps.readLimiter, (req, res, next) => {
-    void req
+  publicNodeRouter.get('/info', deps.readLimiter, (_req, res, next) => {
     try {
       res.send({
         version: deps.version,
@@ -62,8 +60,7 @@ export function createNodeRouters(deps: NodeRouteDependencies): {
   })
 
   /** Detailed node identity and storage report for authenticated operators. */
-  nodeRouter.get('/details', (req, res, next) => {
-    void req
+  nodeRouter.get('/details', (_req, res, next) => {
     try {
       const storage = deps.getStorageMetrics()
       res.send({
@@ -79,6 +76,7 @@ export function createNodeRouters(deps: NodeRouteDependencies): {
         availableBytes: storage.availableBytes,
         reservedBytes: storage.reservedBytes,
         health: {
+          // Keep the complete public Health schema so the OpenAPI $ref remains exact.
           version: deps.version,
           uptimeMs: deps.uptimeMs(),
           ...deps.getHealthSnapshot()

--- a/src/api/nodeRoutes.ts
+++ b/src/api/nodeRoutes.ts
@@ -1,0 +1,94 @@
+import { Router, type RequestHandler } from 'express'
+import type { HealthSnapshot } from '../health/state.js'
+
+/** Runtime values used by the testable node HTTP contract. */
+export interface NodeRouteDependencies {
+  version: string
+  now: () => number
+  uptimeMs: () => number
+  readLimiter: RequestHandler
+  getHeliaStatus: () => string
+  getPeerId: () => string
+  getMultiAddresses: () => string[]
+  getDiskUsageStats: () => {
+    blockstoreSizeMb: number
+    datastoreSizeMb: number
+    availableSizeInMb: number
+  }
+  getStorageMetrics: () => {
+    pinnedBytes: number
+    reclaimableBytes: number
+    availableBytes: number
+    reservedBytes: number
+  }
+  getHealthSnapshot: () => HealthSnapshot
+  getHttpMetrics: () => unknown
+}
+
+/** Build public and administrative node routers from explicit runtime dependencies. */
+export function createNodeRouters(deps: NodeRouteDependencies): {
+  publicNodeRouter: Router
+  nodeRouter: Router
+} {
+  const publicNodeRouter = Router()
+  const nodeRouter = Router()
+
+  publicNodeRouter.get('/health', (req, res, next) => {
+    void req
+    try {
+      res.status(200).send({
+        version: deps.version,
+        uptimeMs: deps.uptimeMs(),
+        ...deps.getHealthSnapshot()
+      })
+    } catch (err) {
+      next(err)
+    }
+  })
+
+  /** Legacy PWA/iOS contract. Keep public and free of node identity or operator data. */
+  publicNodeRouter.get('/info', deps.readLimiter, (req, res, next) => {
+    void req
+    try {
+      res.send({
+        version: deps.version,
+        timestamp: deps.now(),
+        heliaStatus: deps.getHeliaStatus(),
+        ...deps.getDiskUsageStats()
+      })
+    } catch (err) {
+      next(err)
+    }
+  })
+
+  /** Detailed node identity and storage report for authenticated operators. */
+  nodeRouter.get('/details', (req, res, next) => {
+    void req
+    try {
+      const storage = deps.getStorageMetrics()
+      res.send({
+        version: deps.version,
+        timestamp: deps.now(),
+        heliaStatus: deps.getHeliaStatus(),
+        peerId: deps.getPeerId(),
+        multiAddresses: deps.getMultiAddresses(),
+        ...deps.getDiskUsageStats(),
+        // Byte-accurate figures; GET /api/storage/metrics carries the full report.
+        pinnedBytes: storage.pinnedBytes,
+        reclaimableBytes: storage.reclaimableBytes,
+        availableBytes: storage.availableBytes,
+        reservedBytes: storage.reservedBytes,
+        health: {
+          version: deps.version,
+          uptimeMs: deps.uptimeMs(),
+          ...deps.getHealthSnapshot()
+        },
+        http: deps.getHttpMetrics()
+      })
+    } catch (err) {
+      next(err)
+    }
+  })
+
+  return { publicNodeRouter, nodeRouter }
+}

--- a/src/api/nodeRoutes.ts
+++ b/src/api/nodeRoutes.ts
@@ -23,6 +23,8 @@ export interface NodeRouteDependencies {
   }
   getHealthSnapshot: () => HealthSnapshot
   getHttpMetrics: () => unknown
+  /** Admission-limiter occupancy; operator-only, like the byte-accurate figures. */
+  getConcurrencyMetrics: () => unknown
 }
 
 /** Build public and administrative node routers from explicit runtime dependencies. */
@@ -81,7 +83,8 @@ export function createNodeRouters(deps: NodeRouteDependencies): {
           uptimeMs: deps.uptimeMs(),
           ...deps.getHealthSnapshot()
         },
-        http: deps.getHttpMetrics()
+        http: deps.getHttpMetrics(),
+        concurrency: deps.getConcurrencyMetrics()
       })
     } catch (err) {
       next(err)

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -8,7 +8,7 @@ import {
 import { readLimiter } from '../middleware/rateLimiter.js'
 import {
   getReplicationState,
-  repairUnderReplicatedFiles,
+  runManualReplicationRepair,
   ReplicationRepairBusyError
 } from '../replication.cron.js'
 import { getStorageMetrics } from '../storage/metrics.js'
@@ -45,6 +45,7 @@ router.get('/policy', readLimiter, (req, res) => {
     uploadLimitSizeBytes: config.uploadLimitSizeBytes,
     maxRequestSizeBytes: config.storage.maxRequestSizeBytes,
     maxConcurrentUploads: config.storage.maxConcurrentUploads,
+    maxConcurrentDownloads: config.storage.maxConcurrentDownloads,
     confirmationRequired: config.storage.confirmationRequired,
     temporaryTtlMs: config.storage.temporaryTtlMs,
     durability: config.replication.enabled
@@ -105,7 +106,7 @@ storageAdminRouter.post('/gc', async (req, res, next) => {
 /** Detect and repair under-replicated durable content on demand. */
 storageAdminRouter.post('/repair', async (req, res, next) => {
   try {
-    res.send(await repairUnderReplicatedFiles())
+    res.send(await runManualReplicationRepair())
   } catch (err) {
     if (err instanceof ReplicationRepairBusyError) {
       return res.status(409).send({ error: 'Replication repair is already running' })

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -46,6 +46,7 @@ router.get('/policy', readLimiter, (req, res) => {
     maxRequestSizeBytes: config.storage.maxRequestSizeBytes,
     maxConcurrentUploads: config.storage.maxConcurrentUploads,
     maxConcurrentDownloads: config.storage.maxConcurrentDownloads,
+    maxConcurrentDownloadsPerClient: config.storage.maxConcurrentDownloadsPerClient,
     confirmationRequired: config.storage.confirmationRequired,
     temporaryTtlMs: config.storage.temporaryTtlMs,
     durability: config.replication.enabled

--- a/src/api/uploadRoute.ts
+++ b/src/api/uploadRoute.ts
@@ -261,7 +261,8 @@ export function createUploadHandler(dependencies: UploadRouteDependencies): Requ
       }
 
       const files = flatFiles(req.files as UnixFsMulterFile[])
-      log.info(`req.files: ${JSON.stringify(files.map((item) => item.originalname))}`)
+      // Original names belong to the uploader, so only how many arrived is logged.
+      log.info(`Upload request carries ${files.length} file(s)`)
 
       // Hold every CID this request touches while its pin and its record are
       // written, and no longer than that. Sorting happens inside the registry,

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,10 @@ export interface Config {
   maxFileCount: number
   /** Time limit, in milliseconds, for locating a file on the IPFS network. */
   findFileTimeout: number
+  /** Maximum pause between download chunks before retrieval is cancelled. */
+  downloadIdleTimeout: number
+  /** Minimum sustained rate used to derive a size-aware complete-transfer deadline. */
+  downloadMinBytesPerSecond: number
   cors: {
     /** Exact origins and left-most subdomain wildcards; see `src/security/cors.ts`. */
     allowedOrigins: string[]
@@ -326,6 +330,18 @@ export function validateConfig(raw: unknown): Config {
       ? DEFAULT_PEERING_SCHEDULE
       : requireString(root.peeringSchedule, 'peeringSchedule')
   const findFileTimeout = requireInteger(root.findFileTimeout, 'findFileTimeout', 1)
+  const downloadIdleTimeout = optionalInteger(
+    root.downloadIdleTimeout,
+    'downloadIdleTimeout',
+    findFileTimeout,
+    1
+  )
+  const downloadMinBytesPerSecond = optionalInteger(
+    root.downloadMinBytesPerSecond,
+    'downloadMinBytesPerSecond',
+    32 * 1024,
+    1
+  )
   const bootstrap = requireStringArray(peerDiscovery.bootstrap, 'peerDiscovery.bootstrap')
 
   // Owns cors, trustProxy, adminApiKey, enableDebugApi, rateLimits,
@@ -370,6 +386,8 @@ export function validateConfig(raw: unknown): Config {
     uploadLimitSizeBytes: root.uploadLimitSizeBytes as number,
     maxFileCount: root.maxFileCount as number,
     findFileTimeout,
+    downloadIdleTimeout,
+    downloadMinBytesPerSecond,
     cors: { allowedOrigins: cors.allowedOrigins as string[] },
     trustProxy: (root.trustProxy ?? false) as TrustProxySetting,
     rateLimits: root.rateLimits as Config['rateLimits'],

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,9 @@ const currDir = dirname(fileURLToPath(import.meta.url))
 /** Redial unconnected ADAMANT nodes every half minute unless configured otherwise. */
 const DEFAULT_PEERING_SCHEDULE = '*/30 * * * * *'
 
+/** Floor for the absolute download ceiling; the upload limit can raise it. */
+const DEFAULT_DOWNLOAD_MAX_DURATION_MS = 4 * 60 * 60 * 1_000
+
 /** Log levels accepted by `pino`, ordered from least to most verbose. */
 const LOG_LEVELS = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'] as const
 
@@ -344,32 +347,36 @@ export function validateConfig(raw: unknown): Config {
     32 * 1024,
     1
   )
-  const downloadMaxDurationMs = optionalInteger(
-    root.downloadMaxDurationMs,
-    'downloadMaxDurationMs',
-    4 * 60 * 60 * 1_000,
-    1
-  )
-  if (downloadMaxDurationMs < downloadIdleTimeout) {
-    fail('downloadMaxDurationMs', 'must be greater than or equal to downloadIdleTimeout')
-  }
   const bootstrap = requireStringArray(peerDiscovery.bootstrap, 'peerDiscovery.bootstrap')
 
   // Owns cors, trustProxy, adminApiKey, enableDebugApi, rateLimits,
   // uploadLimitSizeBytes and maxFileCount. Throws with its own message.
   validateSecurityConfig(root)
 
-  // The ceiling wins over the size-aware deadline, so one set below the time
-  // the largest permitted file needs would cut those transfers off mid-stream
-  // and report the generic retrieval timeout. Refuse it instead of silently
-  // making large files undownloadable.
-  const largestFileTransferMs =
-    Math.ceil((root.uploadLimitSizeBytes as number) / downloadMinBytesPerSecond) * 1_000
-  if (downloadMaxDurationMs < largestFileTransferMs) {
+  // `downloadFile` clamps its size-aware deadline to this ceiling, so the
+  // ceiling has to carry the largest file this node accepts, with the same idle
+  // headroom that deadline adds. The default is derived from the existing
+  // upload limit so a configuration written before this option stays valid; a
+  // ceiling the operator set explicitly is still refused when it would cut
+  // those transfers off mid-stream and report them as retrieval timeouts.
+  const largestDownloadMs =
+    Math.ceil((root.uploadLimitSizeBytes as number) / downloadMinBytesPerSecond) * 1_000 +
+    downloadIdleTimeout
+  const downloadMaxDurationMs = optionalInteger(
+    root.downloadMaxDurationMs,
+    'downloadMaxDurationMs',
+    Math.max(DEFAULT_DOWNLOAD_MAX_DURATION_MS, largestDownloadMs),
+    1
+  )
+  if (downloadMaxDurationMs < downloadIdleTimeout) {
+    fail('downloadMaxDurationMs', 'must be greater than or equal to downloadIdleTimeout')
+  }
+  if (root.downloadMaxDurationMs !== undefined && downloadMaxDurationMs < largestDownloadMs) {
     fail(
       'downloadMaxDurationMs',
-      `must be at least ${largestFileTransferMs}, the time an ${String(root.uploadLimitSizeBytes)} ` +
-        `byte file needs at downloadMinBytesPerSecond ${downloadMinBytesPerSecond}`
+      `must be at least ${largestDownloadMs}, the time an ${String(root.uploadLimitSizeBytes)} ` +
+        `byte file needs at downloadMinBytesPerSecond ${downloadMinBytesPerSecond} ` +
+        `plus the ${downloadIdleTimeout} ms idle allowance`
     )
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,8 @@ export interface Config {
   downloadIdleTimeout: number
   /** Minimum sustained rate used to derive a size-aware complete-transfer deadline. */
   downloadMinBytesPerSecond: number
+  /** Absolute ceiling for one complete download response. */
+  downloadMaxDurationMs: number
   cors: {
     /** Exact origins and left-most subdomain wildcards; see `src/security/cors.ts`. */
     allowedOrigins: string[]
@@ -342,6 +344,15 @@ export function validateConfig(raw: unknown): Config {
     32 * 1024,
     1
   )
+  const downloadMaxDurationMs = optionalInteger(
+    root.downloadMaxDurationMs,
+    'downloadMaxDurationMs',
+    4 * 60 * 60 * 1_000,
+    1
+  )
+  if (downloadMaxDurationMs < downloadIdleTimeout) {
+    fail('downloadMaxDurationMs', 'must be greater than or equal to downloadIdleTimeout')
+  }
   const bootstrap = requireStringArray(peerDiscovery.bootstrap, 'peerDiscovery.bootstrap')
 
   // Owns cors, trustProxy, adminApiKey, enableDebugApi, rateLimits,
@@ -388,6 +399,7 @@ export function validateConfig(raw: unknown): Config {
     findFileTimeout,
     downloadIdleTimeout,
     downloadMinBytesPerSecond,
+    downloadMaxDurationMs,
     cors: { allowedOrigins: cors.allowedOrigins as string[] },
     trustProxy: (root.trustProxy ?? false) as TrustProxySetting,
     rateLimits: root.rateLimits as Config['rateLimits'],

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,12 +53,32 @@ export interface ConfigNode {
   multiAddr: string
 }
 
+/** Policy used to produce a bounded, network-aware health checkpoint. */
+export interface HealthConfig {
+  /** Length of one checkpoint round, in milliseconds. */
+  checkpointIntervalMs: number
+  /** Maximum age of the last completed checkpoint before it becomes stale. */
+  maxCheckpointAgeMs: number
+  /** Maximum age of the cached storage scan accepted by a checkpoint. */
+  storageMaxAgeMs: number
+  /** Maximum age of a completed full repair sweep. */
+  repairMaxAgeMs: number
+  /** Allowed clock difference between two attesting peers. */
+  clockSkewToleranceMs: number
+  /** Bound for one peer attestation call. */
+  peerAttestationTimeoutMs: number
+  /** Minimum number of configured remote peers that must attest a round. */
+  requiredPeerCount: number
+}
+
 export interface Config {
   /** Known ADAMANT IPFS nodes. Their multiaddrs are also the connection manager allow list. */
   nodes: ConfigNode[]
   /** File storage directory, resolved from the user's home directory. */
   storeFolder: string
   logLevel: LogLevel
+  /** Enable human-oriented log formatting explicitly for local development. */
+  prettyLogs: boolean
   peerDiscovery: {
     /** Multiaddrs dialled on startup to join the ADAMANT peer set. */
     bootstrap: string[]
@@ -94,6 +114,8 @@ export interface Config {
   storage: StorageConfig
   /** Cross-node durability policy; see `src/storage/config.ts`. */
   replication: ReplicationConfig
+  /** Network-aware readiness and checkpoint policy. */
+  health: HealthConfig
 }
 
 /**
@@ -176,6 +198,71 @@ function requireInteger(value: unknown, path: string, min: number): number {
   return value
 }
 
+function optionalInteger(value: unknown, path: string, fallback: number, min: number): number {
+  return value === undefined ? fallback : requireInteger(value, path, min)
+}
+
+/** Resolve health defaults without breaking configuration files from earlier releases. */
+function resolveHealthConfig(value: unknown, nodeCount: number): HealthConfig {
+  const raw = value === undefined ? {} : requireObject(value, 'health')
+  const checkpointIntervalMs = optionalInteger(
+    raw.checkpointIntervalMs,
+    'health.checkpointIntervalMs',
+    60_000,
+    1_000
+  )
+  const maxCheckpointAgeMs = optionalInteger(
+    raw.maxCheckpointAgeMs,
+    'health.maxCheckpointAgeMs',
+    checkpointIntervalMs * 3,
+    checkpointIntervalMs
+  )
+  const storageMaxAgeMs = optionalInteger(
+    raw.storageMaxAgeMs,
+    'health.storageMaxAgeMs',
+    checkpointIntervalMs * 2,
+    checkpointIntervalMs
+  )
+  const repairMaxAgeMs = optionalInteger(
+    raw.repairMaxAgeMs,
+    'health.repairMaxAgeMs',
+    3_600_000,
+    checkpointIntervalMs
+  )
+  const clockSkewToleranceMs = optionalInteger(
+    raw.clockSkewToleranceMs,
+    'health.clockSkewToleranceMs',
+    10_000,
+    0
+  )
+  const peerAttestationTimeoutMs = optionalInteger(
+    raw.peerAttestationTimeoutMs,
+    'health.peerAttestationTimeoutMs',
+    5_000,
+    1
+  )
+  const requiredPeerCount = optionalInteger(
+    raw.requiredPeerCount,
+    'health.requiredPeerCount',
+    nodeCount > 1 ? 1 : 0,
+    0
+  )
+
+  if (requiredPeerCount > Math.max(0, nodeCount - 1)) {
+    fail('health.requiredPeerCount', 'cannot exceed the number of configured remote peers')
+  }
+
+  return {
+    checkpointIntervalMs,
+    maxCheckpointAgeMs,
+    storageMaxAgeMs,
+    repairMaxAgeMs,
+    clockSkewToleranceMs,
+    peerAttestationTimeoutMs,
+    requiredPeerCount
+  }
+}
+
 /**
  * Validate an untrusted parsed config object and return it as a typed `Config`.
  *
@@ -252,9 +339,11 @@ export function validateConfig(raw: unknown): Config {
   // files written before this feature keep working.
   let storage: StorageConfig
   let replication: ReplicationConfig
+  let health: HealthConfig
   try {
     storage = resolveStorageConfig(root.storage, root.uploadLimitSizeBytes as number)
     replication = resolveReplicationConfig(root.replication)
+    health = resolveHealthConfig(root.health, nodes.length)
   } catch (err) {
     if (err instanceof ConfigError) {
       throw err
@@ -273,6 +362,7 @@ export function validateConfig(raw: unknown): Config {
     nodes: nodes.map(({ name, multiAddr }) => ({ name, multiAddr })),
     storeFolder,
     logLevel: logLevel as LogLevel,
+    prettyLogs: root.prettyLogs === true,
     peerDiscovery: { bootstrap, listen },
     serverPort,
     diskUsageScanPeriod,
@@ -286,7 +376,8 @@ export function validateConfig(raw: unknown): Config {
     adminApiKey: (root.adminApiKey ?? '') as string,
     enableDebugApi: root.enableDebugApi === true,
     storage,
-    replication
+    replication,
+    health
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -359,6 +359,20 @@ export function validateConfig(raw: unknown): Config {
   // uploadLimitSizeBytes and maxFileCount. Throws with its own message.
   validateSecurityConfig(root)
 
+  // The ceiling wins over the size-aware deadline, so one set below the time
+  // the largest permitted file needs would cut those transfers off mid-stream
+  // and report the generic retrieval timeout. Refuse it instead of silently
+  // making large files undownloadable.
+  const largestFileTransferMs =
+    Math.ceil((root.uploadLimitSizeBytes as number) / downloadMinBytesPerSecond) * 1_000
+  if (downloadMaxDurationMs < largestFileTransferMs) {
+    fail(
+      'downloadMaxDurationMs',
+      `must be at least ${largestFileTransferMs}, the time an ${String(root.uploadLimitSizeBytes)} ` +
+        `byte file needs at downloadMinBytesPerSecond ${downloadMinBytesPerSecond}`
+    )
+  }
+
   const cors = requireObject(root.cors, 'cors')
 
   // Owns the storage lifecycle and replication policy. Both sections are

--- a/src/disk-usage.cron.ts
+++ b/src/disk-usage.cron.ts
@@ -10,7 +10,7 @@ export const diskUsageCron = new CronJob(config.diskUsageScanPeriod, () => {
   if (!started) {
     started = true
     scan()
-      .catch((err) => logger.error(`${err.message}\n${err.stack}`))
+      .catch((err: Error) => logger.error({ err }, 'Disk usage scan failed'))
       .finally(() => (started = false))
   }
 })
@@ -25,7 +25,7 @@ async function scan() {
   logger.info(`Check folder size took ${Date.now() - start} ms.`)
 }
 
-scan().catch((err) => logger.error(`${err.message}\n${err.stack}`))
+scan().catch((err: Error) => logger.error({ err }, 'Disk usage scan failed'))
 
 /**
  * Disk usage in megabytes, kept for the existing `/api/node/info` payload.

--- a/src/gc.cron.ts
+++ b/src/gc.cron.ts
@@ -71,7 +71,7 @@ export const garbageCollectionCron = new CronJob(config.storage.gc.schedule, () 
   }
 
   logger.info('[Cron] Running "garbageCollection" cronjob.')
-  collectGarbage().catch((err) => logger.error(`${err.message}\n${err.stack}`))
+  collectGarbage().catch((err: Error) => logger.error({ err }, 'Garbage collection failed'))
 })
 
 /**
@@ -82,7 +82,7 @@ export const garbageCollectionCron = new CronJob(config.storage.gc.schedule, () 
  */
 export const admissionRecoveryCron = new CronJob(config.storage.gc.schedule, () => {
   logger.info('[Cron] Running "admissionRecovery" cronjob.')
-  recoverStaleAdmissions().catch((err) => logger.error(`${err.message}\n${err.stack}`))
+  recoverStaleAdmissions().catch((err: Error) => logger.error({ err }, 'Admission recovery failed'))
 })
 
 async function recoverStaleAdmissions(): Promise<void> {

--- a/src/health/membership.ts
+++ b/src/health/membership.ts
@@ -1,0 +1,9 @@
+import { createHash } from 'node:crypto'
+import { peerIdFromMultiaddr } from '../utils/utils.js'
+import type { ConfigNode } from '../config.js'
+
+/** Stable identifier for the configured peer set used by checkpoint attestations. */
+export function membershipVersion(nodes: ConfigNode[]): string {
+  const peerIds = nodes.map((node) => peerIdFromMultiaddr(node.multiAddr).toString()).sort()
+  return createHash('sha256').update(peerIds.join('\n')).digest('hex')
+}

--- a/src/health/persistence.ts
+++ b/src/health/persistence.ts
@@ -34,7 +34,13 @@ export async function loadHealthCheckpoint(store: Datastore): Promise<HealthChec
   }
 }
 
-/** Persist a completed checkpoint atomically through the datastore implementation. */
+/**
+ * Persist a completed checkpoint as one datastore write.
+ *
+ * The whole checkpoint is a single key, so a crash leaves either the previous
+ * value or the new one. That is durability for this record, not a transaction:
+ * a future checkpoint spread over several keys would need one of its own.
+ */
 export async function saveHealthCheckpoint(
   store: Datastore,
   checkpoint: HealthCheckpoint

--- a/src/health/persistence.ts
+++ b/src/health/persistence.ts
@@ -6,26 +6,74 @@ const CHECKPOINT_KEY = new Key('/adm/health/checkpoint')
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 
-function parseCheckpoint(value: unknown): HealthCheckpoint | null {
+/** Shape of a membership version, matching the digest {@link membershipVersion} emits. */
+const MEMBERSHIP_VERSION = /^[0-9a-f]{64}$/
+
+/**
+ * Clock movement tolerated between writing a checkpoint and reading it back.
+ *
+ * A checkpoint dated after the current time is only possible if the clock went
+ * backwards, which invalidates the round it claims.
+ */
+const CLOCK_TOLERANCE_MS = 60_000
+
+function isCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+/**
+ * Accept only a checkpoint this node could have written.
+ *
+ * `Number.isSafeInteger` alone admits negative timestamps and peer counts, and
+ * a height arbitrarily far in the future. The last of those is not merely
+ * cosmetic: `evaluateHealth` carries a height forward with `Math.max`, so one
+ * bad value would be advertised by a `ready` node for the rest of its life and
+ * could never be corrected by a genuine round.
+ */
+export function parseCheckpoint(value: unknown, now: number): HealthCheckpoint | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
+  }
+
   const item = value as Partial<HealthCheckpoint>
 
   if (
-    item === null ||
-    !Number.isSafeInteger(item.height) ||
-    !Number.isSafeInteger(item.completedAt) ||
+    !isCount(item.height) ||
+    !isCount(item.completedAt) ||
+    !isCount(item.attestedPeers) ||
     typeof item.membershipVersion !== 'string' ||
-    !Number.isSafeInteger(item.attestedPeers)
+    !MEMBERSHIP_VERSION.test(item.membershipVersion) ||
+    // The round starts at or before the attempt that completed it.
+    item.height > item.completedAt ||
+    item.completedAt > now + CLOCK_TOLERANCE_MS
   ) {
     return null
   }
 
-  return item as HealthCheckpoint
+  return {
+    height: item.height,
+    completedAt: item.completedAt,
+    membershipVersion: item.membershipVersion,
+    attestedPeers: item.attestedPeers
+  }
 }
 
-/** Load the last durable checkpoint, ignoring malformed legacy or partial data. */
-export async function loadHealthCheckpoint(store: Datastore): Promise<HealthCheckpoint | null> {
+/**
+ * Load the last durable checkpoint, ignoring malformed legacy or partial data.
+ *
+ * @param store node datastore
+ * @param now current time, used to reject a checkpoint from ahead of the clock
+ * @returns the checkpoint, or `null` when there is none this node can trust
+ */
+export async function loadHealthCheckpoint(
+  store: Datastore,
+  now: number = Date.now()
+): Promise<HealthCheckpoint | null> {
   try {
-    return parseCheckpoint(JSON.parse(decoder.decode(await store.get(CHECKPOINT_KEY))) as unknown)
+    return parseCheckpoint(
+      JSON.parse(decoder.decode(await store.get(CHECKPOINT_KEY))) as unknown,
+      now
+    )
   } catch (err) {
     if ((err as { code?: string }).code === 'ERR_NOT_FOUND' || err instanceof SyntaxError) {
       return null

--- a/src/health/persistence.ts
+++ b/src/health/persistence.ts
@@ -1,0 +1,43 @@
+import { Key } from 'interface-datastore'
+import type { Datastore } from 'interface-datastore'
+import type { HealthCheckpoint } from './state.js'
+
+const CHECKPOINT_KEY = new Key('/adm/health/checkpoint')
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+function parseCheckpoint(value: unknown): HealthCheckpoint | null {
+  const item = value as Partial<HealthCheckpoint>
+
+  if (
+    item === null ||
+    !Number.isSafeInteger(item.height) ||
+    !Number.isSafeInteger(item.completedAt) ||
+    typeof item.membershipVersion !== 'string' ||
+    !Number.isSafeInteger(item.attestedPeers)
+  ) {
+    return null
+  }
+
+  return item as HealthCheckpoint
+}
+
+/** Load the last durable checkpoint, ignoring malformed legacy or partial data. */
+export async function loadHealthCheckpoint(store: Datastore): Promise<HealthCheckpoint | null> {
+  try {
+    return parseCheckpoint(JSON.parse(decoder.decode(await store.get(CHECKPOINT_KEY))) as unknown)
+  } catch (err) {
+    if ((err as { code?: string }).code === 'ERR_NOT_FOUND' || err instanceof SyntaxError) {
+      return null
+    }
+    throw err
+  }
+}
+
+/** Persist a completed checkpoint atomically through the datastore implementation. */
+export async function saveHealthCheckpoint(
+  store: Datastore,
+  checkpoint: HealthCheckpoint
+): Promise<void> {
+  await store.put(CHECKPOINT_KEY, encoder.encode(JSON.stringify(checkpoint)))
+}

--- a/src/health/protocol.ts
+++ b/src/health/protocol.ts
@@ -14,6 +14,15 @@ export interface Attestation {
   membershipVersion: string
 }
 
+/** Accept the local fixed round or one adjacent round during a tolerated clock skew. */
+export function isCompatibleRound(
+  requestedRound: number,
+  localRound: number,
+  intervalMs: number
+): boolean {
+  return Math.abs(requestedRound - localRound) <= intervalMs
+}
+
 function encode(message: unknown): Uint8Array {
   const body = new TextEncoder().encode(JSON.stringify(message))
   const frame = new Uint8Array(LENGTH_PREFIX_BYTES + body.byteLength)
@@ -108,14 +117,16 @@ export async function registerHealthProtocol(
 
       if (
         request.membershipVersion !== options.membershipVersion ||
-        request.round !== localRound ||
+        !isCompatibleRound(request.round, localRound, options.checkpointIntervalMs) ||
         Math.abs(timestamp - request.timestamp) > options.clockSkewToleranceMs
       ) {
         throw new Error('Health attestation does not match the local round')
       }
 
       send(stream, {
-        round: localRound,
+        // Echo the accepted request round so the caller gets an attestation for
+        // the checkpoint it is currently evaluating across the boundary.
+        round: request.round,
         timestamp,
         membershipVersion: options.membershipVersion
       })

--- a/src/health/protocol.ts
+++ b/src/health/protocol.ts
@@ -1,0 +1,159 @@
+import type { Connection, Stream } from '@libp2p/interface'
+import type { Multiaddr } from '@multiformats/multiaddr'
+import type { IpfsNode } from '../ipfs-node.js'
+
+export const HEALTH_PROTOCOL_VERSION = '1.0.0'
+export const HEALTH_PROTOCOL = `/adamant/health/${HEALTH_PROTOCOL_VERSION}`
+
+const MAX_MESSAGE_BYTES = 1024
+const LENGTH_PREFIX_BYTES = 4
+
+export interface Attestation {
+  round: number
+  timestamp: number
+  membershipVersion: string
+}
+
+function encode(message: unknown): Uint8Array {
+  const body = new TextEncoder().encode(JSON.stringify(message))
+  const frame = new Uint8Array(LENGTH_PREFIX_BYTES + body.byteLength)
+  new DataView(frame.buffer).setUint32(0, body.byteLength)
+  frame.set(body, LENGTH_PREFIX_BYTES)
+  return frame
+}
+
+function send(stream: Stream, message: unknown): void {
+  stream.send(encode(message))
+}
+
+async function read(stream: Stream, signal: AbortSignal): Promise<unknown> {
+  const abort = (): void => stream.abort(new Error('Health attestation timed out'))
+  signal.addEventListener('abort', abort, { once: true })
+
+  try {
+    const chunks: Uint8Array[] = []
+    let received = 0
+
+    for await (const chunk of stream) {
+      const bytes = chunk instanceof Uint8Array ? chunk : chunk.subarray()
+      chunks.push(bytes)
+      received += bytes.byteLength
+
+      if (received > MAX_MESSAGE_BYTES + LENGTH_PREFIX_BYTES) {
+        throw new Error('Health attestation is too large')
+      }
+      if (received < LENGTH_PREFIX_BYTES) continue
+
+      const buffer = Buffer.concat(chunks)
+      const length = buffer.readUInt32BE(0)
+      if (length > MAX_MESSAGE_BYTES) throw new Error('Health attestation is too large')
+      if (buffer.byteLength >= LENGTH_PREFIX_BYTES + length) {
+        return JSON.parse(
+          buffer.subarray(LENGTH_PREFIX_BYTES, LENGTH_PREFIX_BYTES + length).toString('utf8')
+        ) as unknown
+      }
+    }
+
+    throw new Error('Health stream ended before a complete message arrived')
+  } finally {
+    signal.removeEventListener('abort', abort)
+  }
+}
+
+function parse(value: unknown): Attestation {
+  const message = value as Partial<Attestation>
+  if (
+    !Number.isSafeInteger(message.round) ||
+    !Number.isSafeInteger(message.timestamp) ||
+    typeof message.membershipVersion !== 'string' ||
+    message.membershipVersion.length !== 64
+  ) {
+    throw new Error('Invalid health attestation')
+  }
+  return message as Attestation
+}
+
+export interface HealthProtocolOptions {
+  timeoutMs: number
+  checkpointIntervalMs: number
+  clockSkewToleranceMs: number
+  membershipVersion: string
+  authorizedPeerIds: Set<string>
+  now?: () => number
+  onError?: (message: string) => void
+}
+
+/**
+ * Register the authenticated peer-to-peer checkpoint protocol.
+ *
+ * Authorization uses the peer id proven by the libp2p connection; no HTTP
+ * secret is shared and an unconfigured peer cannot contribute to readiness.
+ */
+export async function registerHealthProtocol(
+  node: IpfsNode,
+  options: HealthProtocolOptions
+): Promise<void> {
+  const now = options.now ?? Date.now
+
+  await node.libp2p.handle(HEALTH_PROTOCOL, (stream, connection: Connection) => {
+    const handle = async (): Promise<void> => {
+      if (!options.authorizedPeerIds.has(connection.remotePeer.toString())) {
+        throw new Error('Health attestation peer is not authorized')
+      }
+
+      const request = parse(await read(stream, AbortSignal.timeout(options.timeoutMs)))
+      const timestamp = now()
+      const localRound =
+        Math.floor(timestamp / options.checkpointIntervalMs) * options.checkpointIntervalMs
+
+      if (
+        request.membershipVersion !== options.membershipVersion ||
+        request.round !== localRound ||
+        Math.abs(timestamp - request.timestamp) > options.clockSkewToleranceMs
+      ) {
+        throw new Error('Health attestation does not match the local round')
+      }
+
+      send(stream, {
+        round: localRound,
+        timestamp,
+        membershipVersion: options.membershipVersion
+      })
+    }
+
+    handle()
+      .then(async () => stream.close())
+      .catch((err: Error) => {
+        options.onError?.(err.message)
+        stream.abort(err)
+      })
+  })
+}
+
+/** Ask one configured peer to attest the same fixed checkpoint round. */
+export async function requestHealthAttestation(
+  node: IpfsNode,
+  peer: Multiaddr,
+  request: Attestation,
+  options: Pick<HealthProtocolOptions, 'timeoutMs' | 'clockSkewToleranceMs'>
+): Promise<void> {
+  const signal = AbortSignal.timeout(options.timeoutMs)
+  const stream = await node.libp2p.dialProtocol(peer, HEALTH_PROTOCOL, { signal })
+  const abort = (): void => stream.abort(new Error('Health attestation timed out'))
+  signal.addEventListener('abort', abort, { once: true })
+
+  try {
+    send(stream, request)
+    const response = parse(await read(stream, signal))
+    if (
+      response.round !== request.round ||
+      response.membershipVersion !== request.membershipVersion ||
+      Math.abs(response.timestamp - request.timestamp) > options.clockSkewToleranceMs
+    ) {
+      throw new Error('Peer attested a different health round')
+    }
+  } finally {
+    signal.removeEventListener('abort', abort)
+    await stream.close().catch(() => {})
+  }
+}

--- a/src/health/service.ts
+++ b/src/health/service.ts
@@ -1,0 +1,169 @@
+import { config } from '../config.js'
+import { helia } from '../helia.js'
+import { datastore } from '../store.js'
+import { getStorageMetrics } from '../storage/metrics.js'
+import { getNodesList } from '../utils/utils.js'
+import { logger } from '../utils/logger.js'
+import { getRepairHealthEvidence } from '../replication.cron.js'
+import { membershipVersion } from './membership.js'
+import { loadHealthCheckpoint, saveHealthCheckpoint } from './persistence.js'
+import { HEALTH_PROTOCOL, registerHealthProtocol, requestHealthAttestation } from './protocol.js'
+import {
+  checkpointRound,
+  evaluateHealth,
+  type HealthCheckpoint,
+  type HealthSnapshot
+} from './state.js'
+
+const networkMembershipVersion = membershipVersion(config.nodes)
+let previous: HealthCheckpoint | null = null
+let startupComplete = false
+let startupHealthy = false
+let running = false
+let rerunRequested = false
+let timer: NodeJS.Timeout | undefined
+
+let snapshot: HealthSnapshot = evaluateHealth(config.health, {
+  now: Date.now(),
+  heliaReady: false,
+  startupComplete: false,
+  startupHealthy: false,
+  storageUpdatedAt: null,
+  storageAvailableBytes: 0,
+  storageReservedBytes: config.storage.diskReserveBytes,
+  repairRequired: config.replication.enabled && config.replication.repairEnabled,
+  repairCompletedAt: null,
+  attestedPeers: 0,
+  membershipVersion: networkMembershipVersion,
+  previous: null
+}).snapshot
+
+async function countAttestations(now: number): Promise<number> {
+  if (config.health.requiredPeerCount === 0) return 0
+
+  const round = checkpointRound(now, config.health.checkpointIntervalMs)
+  const peers = getNodesList([helia.libp2p.peerId.toString()])
+  const answers = await Promise.all(
+    peers.map(async (peer) => {
+      try {
+        await requestHealthAttestation(
+          helia,
+          peer.multiAddr,
+          { round, timestamp: now, membershipVersion: networkMembershipVersion },
+          {
+            timeoutMs: config.health.peerAttestationTimeoutMs,
+            clockSkewToleranceMs: config.health.clockSkewToleranceMs
+          }
+        )
+        return true
+      } catch (err) {
+        logger.debug({ peer: peer.name, err }, 'Health attestation failed')
+        return false
+      }
+    })
+  )
+  return answers.filter(Boolean).length
+}
+
+/** Run one bounded health checkpoint attempt. Overlapping attempts are skipped. */
+export async function runHealthCheckpoint(): Promise<HealthSnapshot> {
+  if (running) {
+    rerunRequested = true
+    return snapshot
+  }
+  running = true
+
+  try {
+    const now = Date.now()
+    const [attestedPeers, repair] = await Promise.all([
+      countAttestations(now),
+      Promise.resolve(getRepairHealthEvidence())
+    ])
+    const storage = getStorageMetrics()
+    const evaluated = evaluateHealth(config.health, {
+      now,
+      heliaReady: helia.libp2p.status === 'started',
+      startupComplete,
+      startupHealthy,
+      storageUpdatedAt: storage.updatedAt,
+      storageAvailableBytes: storage.availableBytes,
+      storageReservedBytes: storage.reservedBytes,
+      repairRequired: repair.required,
+      repairCompletedAt: repair.completedAt,
+      attestedPeers,
+      membershipVersion: networkMembershipVersion,
+      previous
+    })
+
+    if (evaluated.completed !== undefined) {
+      await saveHealthCheckpoint(datastore, evaluated.completed)
+      previous = evaluated.completed
+    }
+    snapshot = evaluated.snapshot
+
+    logger.info(
+      {
+        event: 'health_checkpoint',
+        status: snapshot.status,
+        height: snapshot.height,
+        checks: snapshot.checks,
+        attestedPeers
+      },
+      'Health checkpoint evaluated'
+    )
+    return snapshot
+  } finally {
+    running = false
+    if (rerunRequested) {
+      rerunRequested = false
+      scheduleCheckpoint()
+    }
+  }
+}
+
+function scheduleCheckpoint(): void {
+  void runHealthCheckpoint().catch((err: Error) => {
+    logger.error({ event: 'health_checkpoint_error', err }, 'Health checkpoint failed')
+  })
+}
+
+/** Start the health protocol and the fixed-round checkpoint scheduler. */
+export async function startHealthService(): Promise<void> {
+  previous = await loadHealthCheckpoint(datastore)
+  if (previous?.membershipVersion !== networkMembershipVersion) previous = null
+
+  const authorizedPeerIds = new Set(
+    getNodesList([helia.libp2p.peerId.toString()]).map((peer) => peer.peerId.toString())
+  )
+  await registerHealthProtocol(helia, {
+    timeoutMs: config.health.peerAttestationTimeoutMs,
+    checkpointIntervalMs: config.health.checkpointIntervalMs,
+    clockSkewToleranceMs: config.health.clockSkewToleranceMs,
+    membershipVersion: networkMembershipVersion,
+    authorizedPeerIds,
+    onError: (message) =>
+      logger.warn({ protocol: HEALTH_PROTOCOL, message }, 'Health protocol error')
+  })
+
+  timer = setInterval(scheduleCheckpoint, config.health.checkpointIntervalMs)
+  timer.unref()
+  scheduleCheckpoint()
+}
+
+/** Mark startup reconciliation complete and immediately re-evaluate readiness. */
+export function setStartupReconciliationResult(healthy: boolean): void {
+  startupComplete = true
+  startupHealthy = healthy
+  scheduleCheckpoint()
+}
+
+/** Stop scheduling new health work during graceful shutdown. */
+export function stopHealthService(): void {
+  if (timer !== undefined) clearInterval(timer)
+  timer = undefined
+}
+
+/** Cached, read-only response for the always-200 health endpoint. */
+export function getHealthSnapshot(): HealthSnapshot {
+  return { ...snapshot, timestamp: Date.now() }
+}

--- a/src/health/service.ts
+++ b/src/health/service.ts
@@ -33,6 +33,8 @@ let snapshot: HealthSnapshot = evaluateHealth(config.health, {
   storageReservedBytes: config.storage.diskReserveBytes,
   repairRequired: config.replication.enabled && config.replication.repairEnabled,
   repairCompletedAt: null,
+  repairHealthy: !config.replication.enabled || !config.replication.repairEnabled,
+  repairBacklog: 0,
   attestedPeers: 0,
   membershipVersion: networkMembershipVersion,
   previous: null
@@ -90,6 +92,8 @@ export async function runHealthCheckpoint(): Promise<HealthSnapshot> {
       storageReservedBytes: storage.reservedBytes,
       repairRequired: repair.required,
       repairCompletedAt: repair.completedAt,
+      repairHealthy: repair.healthy,
+      repairBacklog: repair.backlog,
       attestedPeers,
       membershipVersion: networkMembershipVersion,
       previous
@@ -104,7 +108,7 @@ export async function runHealthCheckpoint(): Promise<HealthSnapshot> {
     logger.info(
       {
         event: 'health_checkpoint',
-        status: snapshot.status,
+        state: snapshot.state,
         height: snapshot.height,
         checks: snapshot.checks,
         attestedPeers
@@ -165,5 +169,24 @@ export function stopHealthService(): void {
 
 /** Cached, read-only response for the always-200 health endpoint. */
 export function getHealthSnapshot(): HealthSnapshot {
-  return { ...snapshot, timestamp: Date.now() }
+  const timestamp = Date.now()
+  const currentAge = (observedAt: number | null): number | null =>
+    observedAt === null ? null : Math.max(0, timestamp - observedAt)
+
+  return {
+    ...snapshot,
+    timestamp,
+    checkpoint: {
+      ...snapshot.checkpoint,
+      ageMs: currentAge(snapshot.checkpoint.observedAt)
+    },
+    storage: {
+      ...snapshot.storage,
+      measurementAgeMs: currentAge(snapshot.storage.measuredAt)
+    },
+    replication: {
+      ...snapshot.replication,
+      ageMs: currentAge(snapshot.replication.lastCompleteAt)
+    }
+  }
 }

--- a/src/health/service.ts
+++ b/src/health/service.ts
@@ -73,7 +73,7 @@ async function countAttestations(now: number): Promise<number> {
 export function runHealthCheckpoint(): Promise<HealthSnapshot> {
   if (inFlight !== undefined) {
     rerunRequested = true
-    return Promise.resolve(snapshot)
+    return Promise.resolve(refreshHealthSnapshot(snapshot, Date.now(), config.health))
   }
 
   const run = (async () => {
@@ -178,5 +178,5 @@ export async function stopHealthService(): Promise<void> {
 
 /** Cached, read-only response for the always-200 health endpoint. */
 export function getHealthSnapshot(): HealthSnapshot {
-  return refreshHealthSnapshot(snapshot, Date.now())
+  return refreshHealthSnapshot(snapshot, Date.now(), config.health)
 }

--- a/src/health/service.ts
+++ b/src/health/service.ts
@@ -11,6 +11,7 @@ import { HEALTH_PROTOCOL, registerHealthProtocol, requestHealthAttestation } fro
 import {
   checkpointRound,
   evaluateHealth,
+  refreshHealthSnapshot,
   type HealthCheckpoint,
   type HealthSnapshot
 } from './state.js'
@@ -19,9 +20,10 @@ const networkMembershipVersion = membershipVersion(config.nodes)
 let previous: HealthCheckpoint | null = null
 let startupComplete = false
 let startupHealthy = false
-let running = false
 let rerunRequested = false
+let stopping = false
 let timer: NodeJS.Timeout | undefined
+let inFlight: Promise<HealthSnapshot> | undefined
 
 let snapshot: HealthSnapshot = evaluateHealth(config.health, {
   now: Date.now(),
@@ -68,19 +70,16 @@ async function countAttestations(now: number): Promise<number> {
 }
 
 /** Run one bounded health checkpoint attempt. Overlapping attempts are skipped. */
-export async function runHealthCheckpoint(): Promise<HealthSnapshot> {
-  if (running) {
+export function runHealthCheckpoint(): Promise<HealthSnapshot> {
+  if (inFlight !== undefined) {
     rerunRequested = true
-    return snapshot
+    return Promise.resolve(snapshot)
   }
-  running = true
 
-  try {
+  const run = (async () => {
     const now = Date.now()
-    const [attestedPeers, repair] = await Promise.all([
-      countAttestations(now),
-      Promise.resolve(getRepairHealthEvidence())
-    ])
+    const repair = getRepairHealthEvidence()
+    const attestedPeers = await countAttestations(now)
     const storage = getStorageMetrics()
     const evaluated = evaluateHealth(config.health, {
       now,
@@ -116,16 +115,22 @@ export async function runHealthCheckpoint(): Promise<HealthSnapshot> {
       'Health checkpoint evaluated'
     )
     return snapshot
-  } finally {
-    running = false
-    if (rerunRequested) {
+  })()
+  inFlight = run
+  const finish = (): void => {
+    if (inFlight === run) inFlight = undefined
+    if (rerunRequested && !stopping) {
       rerunRequested = false
       scheduleCheckpoint()
     }
   }
+  void run.then(finish, finish)
+  return run
 }
 
 function scheduleCheckpoint(): void {
+  if (stopping) return
+
   void runHealthCheckpoint().catch((err: Error) => {
     logger.error({ event: 'health_checkpoint_error', err }, 'Health checkpoint failed')
   })
@@ -133,6 +138,7 @@ function scheduleCheckpoint(): void {
 
 /** Start the health protocol and the fixed-round checkpoint scheduler. */
 export async function startHealthService(): Promise<void> {
+  stopping = false
   previous = await loadHealthCheckpoint(datastore)
   if (previous?.membershipVersion !== networkMembershipVersion) previous = null
 
@@ -162,31 +168,15 @@ export function setStartupReconciliationResult(healthy: boolean): void {
 }
 
 /** Stop scheduling new health work during graceful shutdown. */
-export function stopHealthService(): void {
+export async function stopHealthService(): Promise<void> {
+  stopping = true
+  rerunRequested = false
   if (timer !== undefined) clearInterval(timer)
   timer = undefined
+  await inFlight
 }
 
 /** Cached, read-only response for the always-200 health endpoint. */
 export function getHealthSnapshot(): HealthSnapshot {
-  const timestamp = Date.now()
-  const currentAge = (observedAt: number | null): number | null =>
-    observedAt === null ? null : Math.max(0, timestamp - observedAt)
-
-  return {
-    ...snapshot,
-    timestamp,
-    checkpoint: {
-      ...snapshot.checkpoint,
-      ageMs: currentAge(snapshot.checkpoint.observedAt)
-    },
-    storage: {
-      ...snapshot.storage,
-      measurementAgeMs: currentAge(snapshot.storage.measuredAt)
-    },
-    replication: {
-      ...snapshot.replication,
-      ageMs: currentAge(snapshot.replication.lastCompleteAt)
-    }
-  }
+  return refreshHealthSnapshot(snapshot, Date.now())
 }

--- a/src/health/state.ts
+++ b/src/health/state.ts
@@ -59,6 +59,7 @@ export interface HealthSnapshot {
     backlog: number
   }
   checks: {
+    checkpointFresh: boolean
     helia: boolean
     startupReconciliation: boolean
     storageFresh: boolean
@@ -88,7 +89,7 @@ export function evaluateHealth(
   policy: HealthConfig,
   input: HealthInputs
 ): { snapshot: HealthSnapshot; completed?: HealthCheckpoint } {
-  const checks = {
+  const prerequisiteChecks = {
     helia: input.heliaReady,
     startupReconciliation: input.startupComplete && input.startupHealthy,
     storageFresh:
@@ -103,7 +104,7 @@ export function evaluateHealth(
         input.now - input.repairCompletedAt <= policy.repairMaxAgeMs),
     peerAttestations: input.attestedPeers >= policy.requiredPeerCount
   }
-  const complete = Object.values(checks).every(Boolean)
+  const complete = Object.values(prerequisiteChecks).every(Boolean)
   const previousAge = input.previous === null ? null : input.now - input.previous.completedAt
   const state: HealthState = complete
     ? 'ready'
@@ -123,6 +124,13 @@ export function evaluateHealth(
         attestedPeers: input.attestedPeers
       }
     : undefined
+  const checkpointObservedAt = completed?.completedAt ?? input.previous?.completedAt ?? null
+  const checks = {
+    checkpointFresh:
+      checkpointObservedAt !== null &&
+      input.now - checkpointObservedAt <= policy.maxCheckpointAgeMs,
+    ...prerequisiteChecks
+  }
 
   return {
     snapshot: {
@@ -131,8 +139,8 @@ export function evaluateHealth(
       timestamp: input.now,
       checkpoint: {
         intervalMs: policy.checkpointIntervalMs,
-        observedAt: completed?.completedAt ?? input.previous?.completedAt ?? null,
-        ageMs: age(input.now, completed?.completedAt ?? input.previous?.completedAt ?? null),
+        observedAt: checkpointObservedAt,
+        ageMs: age(input.now, checkpointObservedAt),
         maxAgeMs: policy.maxCheckpointAgeMs
       },
       membership: {
@@ -161,9 +169,28 @@ export function evaluateHealth(
   }
 }
 
-/** Refresh elapsed ages and stale state without performing checkpoint I/O. */
-export function refreshHealthSnapshot(current: HealthSnapshot, timestamp: number): HealthSnapshot {
+/** Refresh elapsed ages and freshness checks without performing checkpoint I/O. */
+export function refreshHealthSnapshot(
+  current: HealthSnapshot,
+  timestamp: number,
+  policy: Pick<HealthConfig, 'storageMaxAgeMs' | 'repairMaxAgeMs'>
+): HealthSnapshot {
   const checkpointAge = age(timestamp, current.checkpoint.observedAt)
+  const storageAge = age(timestamp, current.storage.measuredAt)
+  const repairAge = age(timestamp, current.replication.lastCompleteAt)
+  const checks = {
+    ...current.checks,
+    checkpointFresh: checkpointAge !== null && checkpointAge <= current.checkpoint.maxAgeMs,
+    storageFresh:
+      current.checks.storageFresh && storageAge !== null && storageAge <= policy.storageMaxAgeMs,
+    repairFresh:
+      !current.replication.repairRequired ||
+      (current.checks.repairFresh &&
+        current.replication.backlog === 0 &&
+        repairAge !== null &&
+        repairAge <= policy.repairMaxAgeMs)
+  }
+  const freshnessFailed = !checks.storageFresh || !checks.repairFresh
 
   return {
     ...current,
@@ -172,7 +199,9 @@ export function refreshHealthSnapshot(current: HealthSnapshot, timestamp: number
       checkpointAge !== null &&
       checkpointAge > current.checkpoint.maxAgeMs
         ? 'stale'
-        : current.state,
+        : current.state === 'ready' && freshnessFailed
+          ? 'degraded'
+          : current.state,
     timestamp,
     checkpoint: {
       ...current.checkpoint,
@@ -180,11 +209,12 @@ export function refreshHealthSnapshot(current: HealthSnapshot, timestamp: number
     },
     storage: {
       ...current.storage,
-      measurementAgeMs: age(timestamp, current.storage.measuredAt)
+      measurementAgeMs: storageAge
     },
     replication: {
       ...current.replication,
-      ageMs: age(timestamp, current.replication.lastCompleteAt)
-    }
+      ageMs: repairAge
+    },
+    checks
   }
 }

--- a/src/health/state.ts
+++ b/src/health/state.ts
@@ -70,6 +70,8 @@ export interface HealthSnapshot {
   }
   checks: {
     checkpointFresh: boolean
+    /** The clock has not moved behind the checkpoint this node already recorded. */
+    clockConsistent: boolean
     helia: boolean
     startupReconciliation: boolean
     storageFresh: boolean
@@ -100,6 +102,11 @@ export function evaluateHealth(
   input: HealthInputs
 ): { snapshot: HealthSnapshot; completed?: HealthCheckpoint } {
   const prerequisiteChecks = {
+    // A clock behind the last checkpoint would keep the old height through
+    // `Math.max` while stamping a lower `completedAt`, persisting a round that
+    // starts after it finished — the shape `parseCheckpoint` refuses to load.
+    // Advancement waits for the clock instead of recording that.
+    clockConsistent: input.previous === null || input.previous.completedAt <= input.now,
     helia: input.heliaReady,
     startupReconciliation: input.startupComplete && input.startupHealthy,
     storageFresh:
@@ -111,6 +118,9 @@ export function evaluateHealth(
       (input.repairHealthy &&
         input.repairBacklog === 0 &&
         input.repairCompletedAt !== null &&
+        // A completion stamped ahead of the clock is not evidence of freshness;
+        // without the lower bound its negative age would always pass.
+        input.now >= input.repairCompletedAt &&
         input.now - input.repairCompletedAt <= policy.repairMaxAgeMs),
     peerAttestations: input.attestedPeers >= policy.requiredPeerCount
   }
@@ -199,7 +209,8 @@ export function refreshHealthSnapshot(
       (current.checks.repairFresh &&
         current.replication.backlog === 0 &&
         repairAge !== null &&
-        repairAge <= policy.repairMaxAgeMs)
+        repairAge <= policy.repairMaxAgeMs &&
+        timestamp >= (current.replication.lastCompleteAt ?? timestamp))
   }
   const freshnessFailed = !checks.storageFresh || !checks.repairFresh
 

--- a/src/health/state.ts
+++ b/src/health/state.ts
@@ -31,7 +31,17 @@ export interface HealthSnapshot {
   state: HealthState
   /** Monotonic checkpoint height, never a request timestamp. */
   height: number
+  /** Time this response was produced. */
   timestamp: number
+  /**
+   * Time the checkpoint attempt behind this snapshot ran.
+   *
+   * A failed attempt leaves `checkpoint.observedAt` on the last successful
+   * round while `membership`, `startup`, and the non-age checks come from the
+   * attempt that just failed, so those fields are dated by this value and not
+   * by `checkpoint.observedAt`.
+   */
+  evaluatedAt: number
   checkpoint: {
     intervalMs: number
     observedAt: number | null
@@ -137,6 +147,7 @@ export function evaluateHealth(
       state,
       height: completed?.height ?? input.previous?.height ?? 0,
       timestamp: input.now,
+      evaluatedAt: input.now,
       checkpoint: {
         intervalMs: policy.checkpointIntervalMs,
         observedAt: checkpointObservedAt,

--- a/src/health/state.ts
+++ b/src/health/state.ts
@@ -50,8 +50,7 @@ export interface HealthSnapshot {
   storage: {
     measuredAt: number | null
     measurementAgeMs: number | null
-    availableBytes: number
-    reservedBytes: number
+    reserveHealthy: boolean
   }
   replication: {
     repairRequired: boolean
@@ -148,8 +147,7 @@ export function evaluateHealth(
       storage: {
         measuredAt: input.storageUpdatedAt,
         measurementAgeMs: age(input.now, input.storageUpdatedAt),
-        availableBytes: input.storageAvailableBytes,
-        reservedBytes: input.storageReservedBytes
+        reserveHealthy: checks.storageReserve
       },
       replication: {
         repairRequired: input.repairRequired,
@@ -160,5 +158,33 @@ export function evaluateHealth(
       checks
     },
     completed
+  }
+}
+
+/** Refresh elapsed ages and stale state without performing checkpoint I/O. */
+export function refreshHealthSnapshot(current: HealthSnapshot, timestamp: number): HealthSnapshot {
+  const checkpointAge = age(timestamp, current.checkpoint.observedAt)
+
+  return {
+    ...current,
+    state:
+      current.state !== 'starting' &&
+      checkpointAge !== null &&
+      checkpointAge > current.checkpoint.maxAgeMs
+        ? 'stale'
+        : current.state,
+    timestamp,
+    checkpoint: {
+      ...current.checkpoint,
+      ageMs: checkpointAge
+    },
+    storage: {
+      ...current.storage,
+      measurementAgeMs: age(timestamp, current.storage.measuredAt)
+    },
+    replication: {
+      ...current.replication,
+      ageMs: age(timestamp, current.replication.lastCompleteAt)
+    }
   }
 }

--- a/src/health/state.ts
+++ b/src/health/state.ts
@@ -1,0 +1,114 @@
+import type { HealthConfig } from '../config.js'
+
+export type HealthStatus = 'starting' | 'ready' | 'stale' | 'degraded'
+
+export interface HealthCheckpoint {
+  /** Unix milliseconds at the start of the validated fixed round. */
+  height: number
+  completedAt: number
+  membershipVersion: string
+  attestedPeers: number
+}
+
+export interface HealthInputs {
+  now: number
+  heliaReady: boolean
+  startupComplete: boolean
+  startupHealthy: boolean
+  storageUpdatedAt: number | null
+  storageAvailableBytes: number
+  storageReservedBytes: number
+  repairRequired: boolean
+  repairCompletedAt: number | null
+  attestedPeers: number
+  membershipVersion: string
+  previous: HealthCheckpoint | null
+}
+
+export interface HealthSnapshot {
+  status: HealthStatus
+  /** Monotonic checkpoint height, never a request timestamp. */
+  height: number
+  timestamp: number
+  checkpointIntervalMs: number
+  membershipVersion: string
+  checks: {
+    helia: boolean
+    startupReconciliation: boolean
+    storageFresh: boolean
+    storageReserve: boolean
+    repairFresh: boolean
+    peerAttestations: boolean
+  }
+  peerAttestations: {
+    required: number
+    received: number
+  }
+}
+
+/** Return the fixed checkpoint round containing `time`. */
+export function checkpointRound(time: number, intervalMs: number): number {
+  return Math.floor(time / intervalMs) * intervalMs
+}
+
+/**
+ * Evaluate one checkpoint attempt without performing network or datastore I/O.
+ *
+ * A failed attempt freezes the previous height. This is the core compatibility
+ * property used by clients: height only advances after every bounded check for
+ * the same round succeeds.
+ */
+export function evaluateHealth(
+  policy: HealthConfig,
+  input: HealthInputs
+): { snapshot: HealthSnapshot; completed?: HealthCheckpoint } {
+  const checks = {
+    helia: input.heliaReady,
+    startupReconciliation: input.startupComplete && input.startupHealthy,
+    storageFresh:
+      input.storageUpdatedAt !== null &&
+      input.now - input.storageUpdatedAt <= policy.storageMaxAgeMs,
+    storageReserve: input.storageAvailableBytes >= input.storageReservedBytes,
+    repairFresh:
+      !input.repairRequired ||
+      (input.repairCompletedAt !== null &&
+        input.now - input.repairCompletedAt <= policy.repairMaxAgeMs),
+    peerAttestations: input.attestedPeers >= policy.requiredPeerCount
+  }
+  const complete = Object.values(checks).every(Boolean)
+  const previousAge = input.previous === null ? null : input.now - input.previous.completedAt
+  const status: HealthStatus = complete
+    ? 'ready'
+    : !input.startupComplete
+      ? 'starting'
+      : previousAge !== null && previousAge > policy.maxCheckpointAgeMs
+        ? 'stale'
+        : 'degraded'
+  const completed = complete
+    ? {
+        height: Math.max(
+          input.previous?.height ?? 0,
+          checkpointRound(input.now, policy.checkpointIntervalMs)
+        ),
+        completedAt: input.now,
+        membershipVersion: input.membershipVersion,
+        attestedPeers: input.attestedPeers
+      }
+    : undefined
+
+  return {
+    snapshot: {
+      status,
+      height: completed?.height ?? input.previous?.height ?? 0,
+      timestamp: input.now,
+      checkpointIntervalMs: policy.checkpointIntervalMs,
+      membershipVersion: input.membershipVersion,
+      checks,
+      peerAttestations: {
+        required: policy.requiredPeerCount,
+        received: input.attestedPeers
+      }
+    },
+    completed
+  }
+}

--- a/src/health/state.ts
+++ b/src/health/state.ts
@@ -199,20 +199,39 @@ export function refreshHealthSnapshot(
   const checkpointAge = age(timestamp, current.checkpoint.observedAt)
   const storageAge = age(timestamp, current.storage.measuredAt)
   const repairAge = age(timestamp, current.replication.lastCompleteAt)
+
+  // `age` clamps a negative duration to zero, so a clock behind the evidence in
+  // this snapshot would read as brand new rather than as impossible. Each
+  // observation is compared against the request time explicitly instead, and the
+  // endpoint fails safe on the first read after a rollback rather than waiting
+  // for the next scheduled evaluation.
+  const notInFuture = (observedAt: number | null): boolean =>
+    observedAt === null || timestamp >= observedAt
+  const clockConsistent =
+    current.checks.clockConsistent &&
+    notInFuture(current.checkpoint.observedAt) &&
+    notInFuture(current.storage.measuredAt) &&
+    notInFuture(current.replication.lastCompleteAt)
+
   const checks = {
     ...current.checks,
-    checkpointFresh: checkpointAge !== null && checkpointAge <= current.checkpoint.maxAgeMs,
+    clockConsistent,
+    checkpointFresh:
+      clockConsistent && checkpointAge !== null && checkpointAge <= current.checkpoint.maxAgeMs,
     storageFresh:
-      current.checks.storageFresh && storageAge !== null && storageAge <= policy.storageMaxAgeMs,
+      current.checks.storageFresh &&
+      clockConsistent &&
+      storageAge !== null &&
+      storageAge <= policy.storageMaxAgeMs,
     repairFresh:
       !current.replication.repairRequired ||
       (current.checks.repairFresh &&
+        clockConsistent &&
         current.replication.backlog === 0 &&
         repairAge !== null &&
-        repairAge <= policy.repairMaxAgeMs &&
-        timestamp >= (current.replication.lastCompleteAt ?? timestamp))
+        repairAge <= policy.repairMaxAgeMs)
   }
-  const freshnessFailed = !checks.storageFresh || !checks.repairFresh
+  const freshnessFailed = !checks.clockConsistent || !checks.storageFresh || !checks.repairFresh
 
   return {
     ...current,

--- a/src/health/state.ts
+++ b/src/health/state.ts
@@ -1,6 +1,6 @@
 import type { HealthConfig } from '../config.js'
 
-export type HealthStatus = 'starting' | 'ready' | 'stale' | 'degraded'
+export type HealthState = 'starting' | 'ready' | 'stale' | 'degraded'
 
 export interface HealthCheckpoint {
   /** Unix milliseconds at the start of the validated fixed round. */
@@ -20,18 +20,45 @@ export interface HealthInputs {
   storageReservedBytes: number
   repairRequired: boolean
   repairCompletedAt: number | null
+  repairHealthy: boolean
+  repairBacklog: number
   attestedPeers: number
   membershipVersion: string
   previous: HealthCheckpoint | null
 }
 
 export interface HealthSnapshot {
-  status: HealthStatus
+  state: HealthState
   /** Monotonic checkpoint height, never a request timestamp. */
   height: number
   timestamp: number
-  checkpointIntervalMs: number
-  membershipVersion: string
+  checkpoint: {
+    intervalMs: number
+    observedAt: number | null
+    ageMs: number | null
+    maxAgeMs: number
+  }
+  membership: {
+    version: string
+    requiredPeers: number
+    attestedPeers: number
+  }
+  startup: {
+    complete: boolean
+    healthy: boolean
+  }
+  storage: {
+    measuredAt: number | null
+    measurementAgeMs: number | null
+    availableBytes: number
+    reservedBytes: number
+  }
+  replication: {
+    repairRequired: boolean
+    lastCompleteAt: number | null
+    ageMs: number | null
+    backlog: number
+  }
   checks: {
     helia: boolean
     startupReconciliation: boolean
@@ -40,10 +67,10 @@ export interface HealthSnapshot {
     repairFresh: boolean
     peerAttestations: boolean
   }
-  peerAttestations: {
-    required: number
-    received: number
-  }
+}
+
+function age(now: number, observedAt: number | null): number | null {
+  return observedAt === null ? null : Math.max(0, now - observedAt)
 }
 
 /** Return the fixed checkpoint round containing `time`. */
@@ -71,13 +98,15 @@ export function evaluateHealth(
     storageReserve: input.storageAvailableBytes >= input.storageReservedBytes,
     repairFresh:
       !input.repairRequired ||
-      (input.repairCompletedAt !== null &&
+      (input.repairHealthy &&
+        input.repairBacklog === 0 &&
+        input.repairCompletedAt !== null &&
         input.now - input.repairCompletedAt <= policy.repairMaxAgeMs),
     peerAttestations: input.attestedPeers >= policy.requiredPeerCount
   }
   const complete = Object.values(checks).every(Boolean)
   const previousAge = input.previous === null ? null : input.now - input.previous.completedAt
-  const status: HealthStatus = complete
+  const state: HealthState = complete
     ? 'ready'
     : !input.startupComplete
       ? 'starting'
@@ -98,16 +127,37 @@ export function evaluateHealth(
 
   return {
     snapshot: {
-      status,
+      state,
       height: completed?.height ?? input.previous?.height ?? 0,
       timestamp: input.now,
-      checkpointIntervalMs: policy.checkpointIntervalMs,
-      membershipVersion: input.membershipVersion,
-      checks,
-      peerAttestations: {
-        required: policy.requiredPeerCount,
-        received: input.attestedPeers
-      }
+      checkpoint: {
+        intervalMs: policy.checkpointIntervalMs,
+        observedAt: completed?.completedAt ?? input.previous?.completedAt ?? null,
+        ageMs: age(input.now, completed?.completedAt ?? input.previous?.completedAt ?? null),
+        maxAgeMs: policy.maxCheckpointAgeMs
+      },
+      membership: {
+        version: input.membershipVersion,
+        requiredPeers: policy.requiredPeerCount,
+        attestedPeers: input.attestedPeers
+      },
+      startup: {
+        complete: input.startupComplete,
+        healthy: input.startupHealthy
+      },
+      storage: {
+        measuredAt: input.storageUpdatedAt,
+        measurementAgeMs: age(input.now, input.storageUpdatedAt),
+        availableBytes: input.storageAvailableBytes,
+        reservedBytes: input.storageReservedBytes
+      },
+      replication: {
+        repairRequired: input.repairRequired,
+        lastCompleteAt: input.repairCompletedAt,
+        ageMs: age(input.now, input.repairCompletedAt),
+        backlog: input.repairBacklog
+      },
+      checks
     },
     completed
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,11 @@ import { registerReplicationProtocol } from './storage/replicationProtocol.js'
 import { createReplicationHandlers } from './storage/service.js'
 import { fileRegistry } from './storage/state.js'
 import { garbageCollectionCron, admissionRecoveryCron } from './gc.cron.js'
-import { initializeReplicationRepairState, replicationRepairCron } from './replication.cron.js'
+import {
+  initializeReplicationRepairState,
+  startReplicationRepair,
+  stopReplicationRepair
+} from './replication.cron.js'
 import cors from 'cors'
 import * as routers from './api/index.js'
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js'
@@ -70,7 +74,7 @@ function startLifecycleJobs(): void {
 
   if (config.replication.enabled) {
     if (config.replication.repairEnabled) {
-      replicationRepairCron.start()
+      startReplicationRepair()
     }
   } else {
     logger.info('Replication is disabled. Uploaded content is stored best effort on this node.')
@@ -170,8 +174,7 @@ function shutdown(signal: string): void {
   peeringCron.stop()
   garbageCollectionCron.stop()
   admissionRecoveryCron.stop()
-  replicationRepairCron.stop()
-  stopHealthService()
+  const backgroundStopped = Promise.allSettled([stopReplicationRepair(), stopHealthService()])
 
   const forceTimer = setTimeout(() => {
     logger.warn('Shutdown timed out')
@@ -189,8 +192,15 @@ function shutdown(signal: string): void {
 
   server.close(() => {
     clearTimeout(closeIdle)
-    void helia
-      .stop()
+    void backgroundStopped
+      .then((results) => {
+        for (const result of results) {
+          if (result.status === 'rejected') {
+            logger.error(`Background shutdown failed: ${String(result.reason)}`)
+          }
+        }
+        return helia.stop()
+      })
       .catch((err: Error) => logger.error(`helia.stop failed: ${err.message}`))
       .finally(() => {
         clearTimeout(forceTimer)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { registerReplicationProtocol } from './storage/replicationProtocol.js'
 import { createReplicationHandlers } from './storage/service.js'
 import { fileRegistry } from './storage/state.js'
 import { garbageCollectionCron, admissionRecoveryCron } from './gc.cron.js'
-import { replicationRepairCron } from './replication.cron.js'
+import { initializeReplicationRepairState, replicationRepairCron } from './replication.cron.js'
 import cors from 'cors'
 import * as routers from './api/index.js'
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js'
@@ -18,6 +18,12 @@ import { mountApiRoutes } from './security/accessPolicy.js'
 import { createApiKeyAuth } from './security/apiKey.js'
 import { createCorsOriginDelegate } from './security/cors.js'
 import { parseTrustProxy } from './security/trustProxy.js'
+import {
+  setStartupReconciliationResult,
+  startHealthService,
+  stopHealthService
+} from './health/service.js'
+import { collectHttpMetrics } from './observability.js'
 
 logger.info(`Using config file: ${CONFIG_FILE_NAME}`)
 
@@ -41,6 +47,8 @@ const legacyPins = await snapshotPins(helia)
 await registerReplicationProtocol(helia, createReplicationHandlers(), {
   requestTimeoutMs: config.replication.requestTimeoutMs
 })
+await initializeReplicationRepairState()
+await startHealthService()
 
 /** The scheduled work that reads the file registry and acts on what it finds. */
 function startLifecycleJobs(): void {
@@ -100,8 +108,12 @@ void Promise.all([
     if (admissions.recovered > 0) {
       logger.info(`Admission recovery: cleared ${admissions.recovered} interrupted uploads`)
     }
+    setStartupReconciliationResult(backfill.errors.length === 0 && admissions.errors.length === 0)
   })
-  .catch((err: Error) => logger.error(`Startup storage reconciliation failed: ${err.message}`))
+  .catch((err: Error) => {
+    logger.error(`Startup storage reconciliation failed: ${err.message}`)
+    setStartupReconciliationResult(false)
+  })
   // Even a failed reconciliation must not leave the node without a collector:
   // it reclaims nothing that is unregistered, so an incomplete registry makes
   // it do less, never more.
@@ -121,6 +133,7 @@ if (trustProxy === false) {
 }
 
 app.use(httpLogger)
+app.use(collectHttpMetrics)
 
 app.use(
   cors({
@@ -158,6 +171,7 @@ function shutdown(signal: string): void {
   garbageCollectionCron.stop()
   admissionRecoveryCron.stop()
   replicationRepairCron.stop()
+  stopHealthService()
 
   const forceTimer = setTimeout(() => {
     logger.warn('Shutdown timed out')

--- a/src/middleware/downloadAdmission.ts
+++ b/src/middleware/downloadAdmission.ts
@@ -1,23 +1,68 @@
-import type { RequestHandler } from 'express'
+import type { Request, RequestHandler } from 'express'
 
 export interface DownloadConcurrencyLimiter {
   tryAcquire(): boolean
   release(): void
 }
 
-/** Build a global download concurrency guard that releases slots on every response exit. */
-export function createDownloadAdmission(limiter: DownloadConcurrencyLimiter): RequestHandler {
-  return (_req, res, next) => {
+export interface DownloadAdmissionOptions {
+  /**
+   * In-flight downloads one client address may hold at once.
+   *
+   * The global limiter alone bounds what the node spends, not who spends it:
+   * a download slot is held for as long as the transfer runs, so without a
+   * per-client share one address can take every slot and leave the rest of
+   * the network with `429` until those transfers end.
+   */
+  perClientLimit?: number
+  /** Client identity; defaults to the address Express resolved under `trust proxy`. */
+  clientKey?: (req: Request) => string
+}
+
+/** Build a download concurrency guard that releases slots on every response exit. */
+export function createDownloadAdmission(
+  limiter: DownloadConcurrencyLimiter,
+  options: DownloadAdmissionOptions = {}
+): RequestHandler {
+  const { perClientLimit } = options
+  const clientKey = options.clientKey ?? ((req: Request) => req.ip ?? 'unknown')
+
+  // An entry exists only while its client holds a global slot, so this map is
+  // bounded by the global limit and never accumulates addresses.
+  const heldPerClient = new Map<string, number>()
+
+  return (req, res, next) => {
+    const key = clientKey(req)
+    const held = heldPerClient.get(key) ?? 0
+
+    if (perClientLimit !== undefined && held >= perClientLimit) {
+      res.set('Retry-After', '5')
+      res
+        .status(429)
+        .send({ error: 'Too many concurrent downloads from this client. Please try again later.' })
+      return
+    }
+
     if (!limiter.tryAcquire()) {
       res.set('Retry-After', '5')
       res.status(429).send({ error: 'Too many concurrent downloads. Please try again later.' })
       return
     }
 
+    heldPerClient.set(key, held + 1)
+
     let released = false
     const release = (): void => {
       if (released) return
       released = true
+
+      const remaining = (heldPerClient.get(key) ?? 1) - 1
+      if (remaining > 0) {
+        heldPerClient.set(key, remaining)
+      } else {
+        heldPerClient.delete(key)
+      }
+
       limiter.release()
     }
     res.once('finish', release)

--- a/src/middleware/downloadAdmission.ts
+++ b/src/middleware/downloadAdmission.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from 'express'
+
+export interface DownloadConcurrencyLimiter {
+  tryAcquire(): boolean
+  release(): void
+}
+
+/** Build a global download concurrency guard that releases slots on every response exit. */
+export function createDownloadAdmission(limiter: DownloadConcurrencyLimiter): RequestHandler {
+  return (_req, res, next) => {
+    if (!limiter.tryAcquire()) {
+      res.set('Retry-After', '5')
+      res.status(429).send({ error: 'Too many concurrent downloads. Please try again later.' })
+      return
+    }
+
+    let released = false
+    const release = (): void => {
+      if (released) return
+      released = true
+      limiter.release()
+    }
+    res.once('finish', release)
+    res.once('close', release)
+    next()
+  }
+}

--- a/src/middleware/downloadGuards.ts
+++ b/src/middleware/downloadGuards.ts
@@ -1,5 +1,8 @@
+import { config } from '../config.js'
 import { downloadLimiter } from '../storage/state.js'
 import { createDownloadAdmission } from './downloadAdmission.js'
 
-/** Production global concurrency guard for public file retrieval. */
-export const admitDownload = createDownloadAdmission(downloadLimiter)
+/** Production concurrency guard for public file retrieval, global and per client. */
+export const admitDownload = createDownloadAdmission(downloadLimiter, {
+  perClientLimit: config.storage.maxConcurrentDownloadsPerClient
+})

--- a/src/middleware/downloadGuards.ts
+++ b/src/middleware/downloadGuards.ts
@@ -1,0 +1,5 @@
+import { downloadLimiter } from '../storage/state.js'
+import { createDownloadAdmission } from './downloadAdmission.js'
+
+/** Production global concurrency guard for public file retrieval. */
+export const admitDownload = createDownloadAdmission(downloadLimiter)

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -41,10 +41,15 @@ export const collectHttpMetrics: RequestHandler = (req, res, next) => {
 
 /** Snapshot suitable for the authenticated operator details endpoint. */
 export function getHttpMetrics(): HttpMetrics & { averageResponseTimeMs: number } {
+  const completedResponses = Object.values(metrics.responses).reduce(
+    (total, count) => total + count,
+    0
+  )
+
   return {
     ...metrics,
     responses: { ...metrics.responses },
     averageResponseTimeMs:
-      metrics.requests === 0 ? 0 : metrics.totalResponseTimeMs / metrics.requests
+      completedResponses === 0 ? 0 : metrics.totalResponseTimeMs / completedResponses
   }
 }

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,50 @@
+import type { RequestHandler } from 'express'
+
+interface HttpMetrics {
+  requests: number
+  responses: Record<'2xx' | '3xx' | '4xx' | '5xx', number>
+  inFlight: number
+  totalResponseTimeMs: number
+  maxResponseTimeMs: number
+}
+
+const metrics: HttpMetrics = {
+  requests: 0,
+  responses: { '2xx': 0, '3xx': 0, '4xx': 0, '5xx': 0 },
+  inFlight: 0,
+  totalResponseTimeMs: 0,
+  maxResponseTimeMs: 0
+}
+
+/** Bounded HTTP counters with no path, CID, IP, or user-controlled labels. */
+export const collectHttpMetrics: RequestHandler = (req, res, next) => {
+  void req
+  const started = performance.now()
+  let settled = false
+  metrics.requests += 1
+  metrics.inFlight += 1
+
+  const settle = (): void => {
+    if (settled) return
+    settled = true
+    metrics.inFlight -= 1
+    const elapsed = performance.now() - started
+    metrics.totalResponseTimeMs += elapsed
+    metrics.maxResponseTimeMs = Math.max(metrics.maxResponseTimeMs, elapsed)
+    const group = `${Math.floor(res.statusCode / 100)}xx` as keyof HttpMetrics['responses']
+    if (group in metrics.responses) metrics.responses[group] += 1
+  }
+  res.once('finish', settle)
+  res.once('close', settle)
+  next()
+}
+
+/** Snapshot suitable for the authenticated operator details endpoint. */
+export function getHttpMetrics(): HttpMetrics & { averageResponseTimeMs: number } {
+  return {
+    ...metrics,
+    responses: { ...metrics.responses },
+    averageResponseTimeMs:
+      metrics.requests === 0 ? 0 : metrics.totalResponseTimeMs / metrics.requests
+  }
+}

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,5 +1,14 @@
 import type { RequestHandler } from 'express'
 
+/**
+ * Counters accumulated since process start.
+ *
+ * They are deliberately not a sliding window: a window needs retained samples,
+ * and the point of this module is a fixed-size report. `averageResponseTimeMs`
+ * is therefore a lifetime figure, useful as a trend and not as a current
+ * latency reading. A collector scraping `GET /api/node/details` derives rates
+ * by differencing consecutive samples.
+ */
 interface HttpMetrics {
   requests: number
   responses: Record<'2xx' | '3xx' | '4xx' | '5xx', number>

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -12,6 +12,8 @@ import type { RequestHandler } from 'express'
 interface HttpMetrics {
   requests: number
   responses: Record<'2xx' | '3xx' | '4xx' | '5xx', number>
+  /** Responses whose connection closed before the body was finished. */
+  aborted: number
   inFlight: number
   totalResponseTimeMs: number
   maxResponseTimeMs: number
@@ -20,6 +22,7 @@ interface HttpMetrics {
 const metrics: HttpMetrics = {
   requests: 0,
   responses: { '2xx': 0, '3xx': 0, '4xx': 0, '5xx': 0 },
+  aborted: 0,
   inFlight: 0,
   totalResponseTimeMs: 0,
   maxResponseTimeMs: 0
@@ -32,32 +35,40 @@ export const collectHttpMetrics: RequestHandler = (_req, res, next) => {
   metrics.requests += 1
   metrics.inFlight += 1
 
-  const settle = (): void => {
+  const settle = (completed: boolean): void => {
     if (settled) return
     settled = true
     metrics.inFlight -= 1
     const elapsed = performance.now() - started
     metrics.totalResponseTimeMs += elapsed
     metrics.maxResponseTimeMs = Math.max(metrics.maxResponseTimeMs, elapsed)
+
+    // A download sends `200` with its first chunk and can still fail or be
+    // cancelled mid-body. Counting that close in the status family would report
+    // a truncated transfer as a success and hide the late failures this report
+    // exists to surface, so only a finished body reaches a family counter.
+    if (!completed) {
+      metrics.aborted += 1
+      return
+    }
+
     const group = `${Math.floor(res.statusCode / 100)}xx` as keyof HttpMetrics['responses']
     if (group in metrics.responses) metrics.responses[group] += 1
   }
-  res.once('finish', settle)
-  res.once('close', settle)
+  res.once('finish', () => settle(true))
+  res.once('close', () => settle(res.writableFinished))
   next()
 }
 
 /** Snapshot suitable for the authenticated operator details endpoint. */
 export function getHttpMetrics(): HttpMetrics & { averageResponseTimeMs: number } {
-  const completedResponses = Object.values(metrics.responses).reduce(
-    (total, count) => total + count,
-    0
-  )
+  const settledResponses =
+    Object.values(metrics.responses).reduce((total, count) => total + count, 0) + metrics.aborted
 
   return {
     ...metrics,
     responses: { ...metrics.responses },
     averageResponseTimeMs:
-      completedResponses === 0 ? 0 : metrics.totalResponseTimeMs / completedResponses
+      settledResponses === 0 ? 0 : metrics.totalResponseTimeMs / settledResponses
   }
 }

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -17,8 +17,7 @@ const metrics: HttpMetrics = {
 }
 
 /** Bounded HTTP counters with no path, CID, IP, or user-controlled labels. */
-export const collectHttpMetrics: RequestHandler = (req, res, next) => {
-  void req
+export const collectHttpMetrics: RequestHandler = (_req, res, next) => {
   const started = performance.now()
   let settled = false
   metrics.requests += 1

--- a/src/peering.cron.ts
+++ b/src/peering.cron.ts
@@ -55,7 +55,7 @@ export const peeringCron = new CronJob(config.peeringSchedule, () => {
 
   running = true
   peerWithKnownNodes()
-    .catch((err: Error) => logger.error(`${err.message}\n${err.stack}`))
+    .catch((err: Error) => logger.error({ err }, 'Peering cycle failed'))
     .finally(() => (running = false))
 })
 

--- a/src/replication.cron.ts
+++ b/src/replication.cron.ts
@@ -45,12 +45,12 @@ async function loadEvidence(now: number = Date.now()): Promise<RepairCycleEviden
 
   try {
     const stored = await datastore.get(REPAIR_STATE_KEY)
-    let parsed: Partial<RepairCycleEvidence>
+    let parsed: unknown
     try {
-      parsed = JSON.parse(decoder.decode(stored)) as Partial<RepairCycleEvidence>
+      parsed = JSON.parse(decoder.decode(stored)) as unknown
     } catch {
       logger.warn('Ignoring malformed persisted repair-cycle evidence')
-      parsed = {}
+      parsed = null
     }
     evidence = parseEvidence(parsed, now) ?? emptyEvidence(now)
   } catch (err) {

--- a/src/replication.cron.ts
+++ b/src/replication.cron.ts
@@ -20,6 +20,8 @@ interface RepairCycleEvidence {
   policyVersion: string
   cursor?: string
   startedAt: number
+  /** Records were admitted behind the cursor, so this cycle cannot cover them. */
+  superseded: boolean
   examined: number
   checked: number
   underReplicated: number
@@ -42,6 +44,7 @@ function emptyEvidence(now = Date.now()): RepairCycleEvidence {
     membershipVersion: membershipVersion(config.nodes),
     policyVersion: currentPolicyVersion(),
     startedAt: now,
+    superseded: false,
     examined: 0,
     checked: 0,
     underReplicated: 0,
@@ -72,6 +75,7 @@ async function loadEvidence(): Promise<RepairCycleEvidence> {
       (parsed.cursor === undefined || typeof parsed.cursor === 'string') &&
       Number.isSafeInteger(parsed.startedAt) &&
       (parsed.examined === undefined || Number.isSafeInteger(parsed.examined)) &&
+      (parsed.superseded === undefined || typeof parsed.superseded === 'boolean') &&
       Number.isSafeInteger(parsed.checked) &&
       Number.isSafeInteger(parsed.underReplicated) &&
       Number.isSafeInteger(parsed.repaired) &&
@@ -80,7 +84,11 @@ async function loadEvidence(): Promise<RepairCycleEvidence> {
       (parsed.lastCompletedAt === null || Number.isSafeInteger(parsed.lastCompletedAt)) &&
       typeof parsed.lastCompletedSuccessfully === 'boolean' &&
       Number.isSafeInteger(parsed.lastCompletedBacklog)
-        ? ({ ...parsed, examined: parsed.examined ?? parsed.checked } as RepairCycleEvidence)
+        ? ({
+            ...parsed,
+            examined: parsed.examined ?? parsed.checked,
+            superseded: parsed.superseded ?? false
+          } as RepairCycleEvidence)
         : emptyEvidence()
   } catch (err) {
     if ((err as { code?: string }).code !== 'ERR_NOT_FOUND') throw err
@@ -131,25 +139,46 @@ export async function repairUnderReplicatedFiles(): Promise<RepairReport> {
       stillMissing: current.stillMissing + lastReport.stillMissing.length,
       unrecoverable: current.unrecoverable + lastReport.unrecoverable.length
     }
-    const completedAt = lastReport.cycleCompleted ? Date.now() : current.lastCompletedAt
-    const completedSuccessfully = lastReport.cycleCompleted
-      ? aggregate.stillMissing === 0 && aggregate.unrecoverable === 0
-      : current.lastCompletedSuccessfully
+
+    // A cycle whose catch-up rounds ran out ended without covering everything
+    // that arrived while it walked. It still finishes and hands the cursor back,
+    // but it is not published as fresh durability evidence: the last genuinely
+    // complete cycle stays in place instead, so readiness decays on its own
+    // schedule rather than advancing on a coverage gap.
+    const superseded = current.superseded || lastReport.uncovered > 0
+    const publishes = lastReport.cycleCompleted && !superseded
 
     await saveEvidence(
       lastReport.cycleCompleted
         ? {
             ...emptyEvidence(),
-            lastCompletedAt: completedAt,
-            lastCompletedSuccessfully: completedSuccessfully,
-            lastCompletedBacklog: aggregate.stillMissing + aggregate.unrecoverable
+            lastCompletedAt: publishes ? Date.now() : current.lastCompletedAt,
+            lastCompletedSuccessfully: publishes
+              ? aggregate.stillMissing === 0 && aggregate.unrecoverable === 0
+              : current.lastCompletedSuccessfully,
+            lastCompletedBacklog: publishes
+              ? aggregate.stillMissing + aggregate.unrecoverable
+              : current.lastCompletedBacklog
           }
         : {
             ...current,
+            superseded,
             cursor: lastReport.nextCursor,
             ...aggregate
           }
     )
+
+    if (lastReport.cycleCompleted && superseded) {
+      logger.warn(
+        {
+          event: 'replication_repair_cycle_superseded',
+          examined: aggregate.examined,
+          uncovered: lastReport.uncovered
+        },
+        'Repair cycle finished without covering records admitted while it ran; ' +
+          'keeping the previous completed cycle as evidence'
+      )
+    }
 
     if (lastReport.underReplicated > 0) {
       logger.info(
@@ -176,15 +205,17 @@ export const replicationRepairCron = new CronJob(config.replication.repairSchedu
  * both resume the cursor a previous pass left behind.
  */
 function logRepairPass(trigger: RepairTrigger): void {
-  const cursor = evidence?.cursor ?? null
+  const resuming = evidence?.cursor !== undefined
 
   logger.info(
     {
       event: 'replication_repair_pass',
       trigger,
-      cursor
+      resuming,
+      // Bounded progress instead of the cursor, which is a CID.
+      examined: evidence?.examined ?? 0
     },
-    cursor === null ? 'Starting replication repair cycle' : 'Continuing replication repair cycle'
+    resuming ? 'Continuing replication repair cycle' : 'Starting replication repair cycle'
   )
 }
 
@@ -193,13 +224,13 @@ const repairCycleDriver = new RepairCycleDriver({
   runPass: repairUnderReplicatedFiles,
   busyError: () => new ReplicationRepairBusyError(),
   onStart: logRepairPass,
-  onError: (err) => logger.error(`${err.message}\n${err.stack}`),
+  onError: (err) => logger.error({ err }, 'Replication repair pass failed'),
   onAbandon: (err, failures) =>
     logger.error(
       {
         event: 'replication_repair_cycle_abandoned',
         failures,
-        cursor: evidence?.cursor ?? null,
+        examined: evidence?.examined ?? 0,
         err
       },
       'Replication repair cycle abandoned after repeated failures; it resumes on the next schedule'
@@ -238,6 +269,7 @@ export function getReplicationState() {
     cycle: evidence
       ? {
           startedAt: evidence.startedAt,
+          superseded: evidence.superseded,
           examined: evidence.examined,
           checked: evidence.checked,
           underReplicated: evidence.underReplicated,

--- a/src/replication.cron.ts
+++ b/src/replication.cron.ts
@@ -8,30 +8,13 @@ import { Key } from 'interface-datastore'
 import { createHash } from 'node:crypto'
 import { membershipVersion } from './health/membership.js'
 import { RepairCycleDriver, type RepairTrigger } from './storage/repairCycleDriver.js'
+import { parseEvidence, type RepairCycleEvidence } from './storage/repairEvidence.js'
 
 let running = false
 let lastReport: RepairReport | null = null
 const REPAIR_STATE_KEY = new Key('/adm/health/repair-cycle')
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
-
-interface RepairCycleEvidence {
-  membershipVersion: string
-  policyVersion: string
-  cursor?: string
-  startedAt: number
-  /** Records were admitted behind the cursor, so this cycle cannot cover them. */
-  superseded: boolean
-  examined: number
-  checked: number
-  underReplicated: number
-  repaired: number
-  stillMissing: number
-  unrecoverable: number
-  lastCompletedAt: number | null
-  lastCompletedSuccessfully: boolean
-  lastCompletedBacklog: number
-}
 
 let evidence: RepairCycleEvidence | null = null
 
@@ -57,7 +40,7 @@ function emptyEvidence(now = Date.now()): RepairCycleEvidence {
   }
 }
 
-async function loadEvidence(): Promise<RepairCycleEvidence> {
+async function loadEvidence(now: number = Date.now()): Promise<RepairCycleEvidence> {
   if (evidence !== null) return evidence
 
   try {
@@ -69,37 +52,17 @@ async function loadEvidence(): Promise<RepairCycleEvidence> {
       logger.warn('Ignoring malformed persisted repair-cycle evidence')
       parsed = {}
     }
-    evidence =
-      typeof parsed.membershipVersion === 'string' &&
-      typeof parsed.policyVersion === 'string' &&
-      (parsed.cursor === undefined || typeof parsed.cursor === 'string') &&
-      Number.isSafeInteger(parsed.startedAt) &&
-      (parsed.examined === undefined || Number.isSafeInteger(parsed.examined)) &&
-      (parsed.superseded === undefined || typeof parsed.superseded === 'boolean') &&
-      Number.isSafeInteger(parsed.checked) &&
-      Number.isSafeInteger(parsed.underReplicated) &&
-      Number.isSafeInteger(parsed.repaired) &&
-      Number.isSafeInteger(parsed.stillMissing) &&
-      Number.isSafeInteger(parsed.unrecoverable) &&
-      (parsed.lastCompletedAt === null || Number.isSafeInteger(parsed.lastCompletedAt)) &&
-      typeof parsed.lastCompletedSuccessfully === 'boolean' &&
-      Number.isSafeInteger(parsed.lastCompletedBacklog)
-        ? ({
-            ...parsed,
-            examined: parsed.examined ?? parsed.checked,
-            superseded: parsed.superseded ?? false
-          } as RepairCycleEvidence)
-        : emptyEvidence()
+    evidence = parseEvidence(parsed, now) ?? emptyEvidence(now)
   } catch (err) {
     if ((err as { code?: string }).code !== 'ERR_NOT_FOUND') throw err
-    evidence = emptyEvidence()
+    evidence = emptyEvidence(now)
   }
 
   if (
     evidence.membershipVersion !== membershipVersion(config.nodes) ||
     evidence.policyVersion !== currentPolicyVersion()
   ) {
-    evidence = emptyEvidence()
+    evidence = emptyEvidence(now)
   }
 
   return evidence
@@ -145,7 +108,7 @@ export async function repairUnderReplicatedFiles(): Promise<RepairReport> {
     // but it is not published as fresh durability evidence: the last genuinely
     // complete cycle stays in place instead, so readiness decays on its own
     // schedule rather than advancing on a coverage gap.
-    const superseded = current.superseded || lastReport.uncovered > 0
+    const superseded = current.superseded || lastReport.uncovered > 0 || !lastReport.coverageProven
     const publishes = lastReport.cycleCompleted && !superseded
 
     await saveEvidence(

--- a/src/replication.cron.ts
+++ b/src/replication.cron.ts
@@ -7,6 +7,7 @@ import { datastore } from './store.js'
 import { Key } from 'interface-datastore'
 import { createHash } from 'node:crypto'
 import { membershipVersion } from './health/membership.js'
+import { RepairCycleDriver, type RepairTrigger } from './storage/repairCycleDriver.js'
 
 let running = false
 let lastReport: RepairReport | null = null
@@ -164,46 +165,45 @@ export async function repairUnderReplicatedFiles(): Promise<RepairReport> {
 }
 
 export const replicationRepairCron = new CronJob(config.replication.repairSchedule, () => {
-  void runScheduledRepair()
+  repairCycleDriver.triggerSchedule()
 })
 
-let stopping = false
-let continuationTimer: NodeJS.Timeout | undefined
-let scheduledInFlight: Promise<void> | undefined
+function logRepairPass(trigger: RepairTrigger): void {
+  logger.info(
+    {
+      event: 'replication_repair_pass',
+      trigger,
+      cursor: evidence?.cursor ?? null
+    },
+    trigger === 'continuation'
+      ? 'Continuing replication repair cycle'
+      : 'Starting replication repair cycle'
+  )
+}
 
-async function runScheduledRepair(): Promise<void> {
-  if (stopping || running || continuationTimer !== undefined) return
+const repairCycleDriver = new RepairCycleDriver({
+  delayMs: config.replication.repairBatchDelayMs,
+  runPass: repairUnderReplicatedFiles,
+  busyError: () => new ReplicationRepairBusyError(),
+  onStart: logRepairPass,
+  onError: (err) => logger.error(`${err.message}\n${err.stack}`)
+})
 
-  logger.info('[Cron] Running "replicationRepair" cronjob.')
-  const run = repairUnderReplicatedFiles()
-    .then((report) => {
-      if (stopping || report.cycleCompleted) return
-      continuationTimer = setTimeout(() => {
-        continuationTimer = undefined
-        void runScheduledRepair()
-      }, config.replication.repairBatchDelayMs)
-      continuationTimer.unref()
-    })
-    .catch((err: Error) => logger.error(`${err.message}\n${err.stack}`))
-  scheduledInFlight = run
-  await run
-  if (scheduledInFlight === run) scheduledInFlight = undefined
+/** Run one manual pass without interrupting automatic cycle continuation. */
+export function runManualReplicationRepair(): Promise<RepairReport> {
+  return repairCycleDriver.runManual()
 }
 
 /** Start the periodic repair job and immediately begin the first full cycle. */
 export function startReplicationRepair(): void {
-  stopping = false
   replicationRepairCron.start()
-  void runScheduledRepair()
+  repairCycleDriver.start()
 }
 
 /** Stop scheduled repair work and wait for the active bounded pass. */
 export async function stopReplicationRepair(): Promise<void> {
-  stopping = true
   replicationRepairCron.stop()
-  if (continuationTimer !== undefined) clearTimeout(continuationTimer)
-  continuationTimer = undefined
-  await scheduledInFlight
+  await repairCycleDriver.stop()
 }
 
 export function getReplicationState() {

--- a/src/replication.cron.ts
+++ b/src/replication.cron.ts
@@ -168,16 +168,23 @@ export const replicationRepairCron = new CronJob(config.replication.repairSchedu
   repairCycleDriver.triggerSchedule()
 })
 
+/**
+ * Report one bounded pass.
+ *
+ * Whether a pass starts a cycle is decided by the persisted cursor, not by the
+ * trigger: a manual pass, and a schedule tick that follows an abandoned cycle,
+ * both resume the cursor a previous pass left behind.
+ */
 function logRepairPass(trigger: RepairTrigger): void {
+  const cursor = evidence?.cursor ?? null
+
   logger.info(
     {
       event: 'replication_repair_pass',
       trigger,
-      cursor: evidence?.cursor ?? null
+      cursor
     },
-    trigger === 'continuation'
-      ? 'Continuing replication repair cycle'
-      : 'Starting replication repair cycle'
+    cursor === null ? 'Starting replication repair cycle' : 'Continuing replication repair cycle'
   )
 }
 
@@ -186,7 +193,17 @@ const repairCycleDriver = new RepairCycleDriver({
   runPass: repairUnderReplicatedFiles,
   busyError: () => new ReplicationRepairBusyError(),
   onStart: logRepairPass,
-  onError: (err) => logger.error(`${err.message}\n${err.stack}`)
+  onError: (err) => logger.error(`${err.message}\n${err.stack}`),
+  onAbandon: (err, failures) =>
+    logger.error(
+      {
+        event: 'replication_repair_cycle_abandoned',
+        failures,
+        cursor: evidence?.cursor ?? null,
+        err
+      },
+      'Replication repair cycle abandoned after repeated failures; it resumes on the next schedule'
+    )
 })
 
 /** Run one manual pass without interrupting automatic cycle continuation. */

--- a/src/replication.cron.ts
+++ b/src/replication.cron.ts
@@ -3,9 +3,97 @@ import { config } from './config.js'
 import { REPLICATION_PROTOCOL } from './storage/replicationProtocol.js'
 import { repairReplication, type RepairReport } from './storage/service.js'
 import { logger } from './utils/logger.js'
+import { datastore } from './store.js'
+import { Key } from 'interface-datastore'
+import { createHash } from 'node:crypto'
+import { membershipVersion } from './health/membership.js'
 
 let running = false
 let lastReport: RepairReport | null = null
+const REPAIR_STATE_KEY = new Key('/adm/health/repair-cycle')
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+interface RepairCycleEvidence {
+  membershipVersion: string
+  policyVersion: string
+  cursor?: string
+  startedAt: number
+  checked: number
+  underReplicated: number
+  repaired: number
+  stillMissing: number
+  unrecoverable: number
+  lastCompletedAt: number | null
+  lastCompletedSuccessfully: boolean
+}
+
+let evidence: RepairCycleEvidence | null = null
+
+function currentPolicyVersion(): string {
+  return createHash('sha256').update(JSON.stringify(config.replication.placement)).digest('hex')
+}
+
+function emptyEvidence(now = Date.now()): RepairCycleEvidence {
+  return {
+    membershipVersion: membershipVersion(config.nodes),
+    policyVersion: currentPolicyVersion(),
+    startedAt: now,
+    checked: 0,
+    underReplicated: 0,
+    repaired: 0,
+    stillMissing: 0,
+    unrecoverable: 0,
+    lastCompletedAt: config.replication.enabled && config.replication.repairEnabled ? null : now,
+    lastCompletedSuccessfully: !config.replication.enabled || !config.replication.repairEnabled
+  }
+}
+
+async function loadEvidence(): Promise<RepairCycleEvidence> {
+  if (evidence !== null) return evidence
+
+  try {
+    const stored = await datastore.get(REPAIR_STATE_KEY)
+    let parsed: Partial<RepairCycleEvidence>
+    try {
+      parsed = JSON.parse(decoder.decode(stored)) as Partial<RepairCycleEvidence>
+    } catch {
+      logger.warn('Ignoring malformed persisted repair-cycle evidence')
+      parsed = {}
+    }
+    evidence =
+      typeof parsed.membershipVersion === 'string' &&
+      typeof parsed.policyVersion === 'string' &&
+      (parsed.cursor === undefined || typeof parsed.cursor === 'string') &&
+      Number.isSafeInteger(parsed.startedAt) &&
+      Number.isSafeInteger(parsed.checked) &&
+      Number.isSafeInteger(parsed.underReplicated) &&
+      Number.isSafeInteger(parsed.repaired) &&
+      Number.isSafeInteger(parsed.stillMissing) &&
+      Number.isSafeInteger(parsed.unrecoverable) &&
+      (parsed.lastCompletedAt === null || Number.isSafeInteger(parsed.lastCompletedAt)) &&
+      typeof parsed.lastCompletedSuccessfully === 'boolean'
+        ? (parsed as RepairCycleEvidence)
+        : emptyEvidence()
+  } catch (err) {
+    if ((err as { code?: string }).code !== 'ERR_NOT_FOUND') throw err
+    evidence = emptyEvidence()
+  }
+
+  if (
+    evidence.membershipVersion !== membershipVersion(config.nodes) ||
+    evidence.policyVersion !== currentPolicyVersion()
+  ) {
+    evidence = emptyEvidence()
+  }
+
+  return evidence
+}
+
+async function saveEvidence(value: RepairCycleEvidence): Promise<void> {
+  await datastore.put(REPAIR_STATE_KEY, encoder.encode(JSON.stringify(value)))
+  evidence = value
+}
 
 export class ReplicationRepairBusyError extends Error {
   constructor() {
@@ -25,7 +113,34 @@ export async function repairUnderReplicatedFiles(): Promise<RepairReport> {
 
   running = true
   try {
-    lastReport = await repairReplication()
+    const current = await loadEvidence()
+    lastReport = await repairReplication({ cursor: current.cursor })
+
+    const aggregate = {
+      checked: current.checked + lastReport.checked,
+      underReplicated: current.underReplicated + lastReport.underReplicated,
+      repaired: current.repaired + lastReport.repaired.length,
+      stillMissing: current.stillMissing + lastReport.stillMissing.length,
+      unrecoverable: current.unrecoverable + lastReport.unrecoverable.length
+    }
+    const completedAt = lastReport.cycleCompleted ? Date.now() : current.lastCompletedAt
+    const completedSuccessfully = lastReport.cycleCompleted
+      ? aggregate.stillMissing === 0 && aggregate.unrecoverable === 0
+      : current.lastCompletedSuccessfully
+
+    await saveEvidence(
+      lastReport.cycleCompleted
+        ? {
+            ...emptyEvidence(),
+            lastCompletedAt: completedAt,
+            lastCompletedSuccessfully: completedSuccessfully
+          }
+        : {
+            ...current,
+            cursor: lastReport.nextCursor,
+            ...aggregate
+          }
+    )
 
     if (lastReport.underReplicated > 0) {
       logger.info(
@@ -61,14 +176,47 @@ export function getReplicationState() {
     repairEnabled: config.replication.repairEnabled,
     repairSchedule: config.replication.repairSchedule,
     running,
+    cycle: evidence
+      ? {
+          startedAt: evidence.startedAt,
+          checked: evidence.checked,
+          underReplicated: evidence.underReplicated,
+          repaired: evidence.repaired,
+          stillMissing: evidence.stillMissing,
+          unrecoverable: evidence.unrecoverable,
+          lastCompletedAt: evidence.lastCompletedAt,
+          lastCompletedSuccessfully: evidence.lastCompletedSuccessfully
+        }
+      : null,
     lastRun: lastReport
       ? {
           checked: lastReport.checked,
           underReplicated: lastReport.underReplicated,
           repaired: lastReport.repaired.length,
           stillMissing: lastReport.stillMissing.length,
-          rescued: lastReport.rescued.length
+          rescued: lastReport.rescued.length,
+          unrecoverable: lastReport.unrecoverable.length
         }
       : null
+  }
+}
+
+/** Restore repair evidence before the first health checkpoint is evaluated. */
+export async function initializeReplicationRepairState(): Promise<void> {
+  await loadEvidence()
+}
+
+/** Last successful complete repair cycle used by the health checkpoint. */
+export function getRepairHealthEvidence(): {
+  required: boolean
+  completedAt: number | null
+} {
+  const required = config.replication.enabled && config.replication.repairEnabled
+  return {
+    required,
+    completedAt:
+      !required || evidence?.lastCompletedSuccessfully === true
+        ? (evidence?.lastCompletedAt ?? Date.now())
+        : null
   }
 }

--- a/src/replication.cron.ts
+++ b/src/replication.cron.ts
@@ -19,6 +19,7 @@ interface RepairCycleEvidence {
   policyVersion: string
   cursor?: string
   startedAt: number
+  examined: number
   checked: number
   underReplicated: number
   repaired: number
@@ -40,6 +41,7 @@ function emptyEvidence(now = Date.now()): RepairCycleEvidence {
     membershipVersion: membershipVersion(config.nodes),
     policyVersion: currentPolicyVersion(),
     startedAt: now,
+    examined: 0,
     checked: 0,
     underReplicated: 0,
     repaired: 0,
@@ -68,6 +70,7 @@ async function loadEvidence(): Promise<RepairCycleEvidence> {
       typeof parsed.policyVersion === 'string' &&
       (parsed.cursor === undefined || typeof parsed.cursor === 'string') &&
       Number.isSafeInteger(parsed.startedAt) &&
+      (parsed.examined === undefined || Number.isSafeInteger(parsed.examined)) &&
       Number.isSafeInteger(parsed.checked) &&
       Number.isSafeInteger(parsed.underReplicated) &&
       Number.isSafeInteger(parsed.repaired) &&
@@ -76,7 +79,7 @@ async function loadEvidence(): Promise<RepairCycleEvidence> {
       (parsed.lastCompletedAt === null || Number.isSafeInteger(parsed.lastCompletedAt)) &&
       typeof parsed.lastCompletedSuccessfully === 'boolean' &&
       Number.isSafeInteger(parsed.lastCompletedBacklog)
-        ? (parsed as RepairCycleEvidence)
+        ? ({ ...parsed, examined: parsed.examined ?? parsed.checked } as RepairCycleEvidence)
         : emptyEvidence()
   } catch (err) {
     if ((err as { code?: string }).code !== 'ERR_NOT_FOUND') throw err
@@ -120,6 +123,7 @@ export async function repairUnderReplicatedFiles(): Promise<RepairReport> {
     lastReport = await repairReplication({ cursor: current.cursor })
 
     const aggregate = {
+      examined: current.examined + lastReport.examined,
       checked: current.checked + lastReport.checked,
       underReplicated: current.underReplicated + lastReport.underReplicated,
       repaired: current.repaired + lastReport.repaired.length,
@@ -160,13 +164,47 @@ export async function repairUnderReplicatedFiles(): Promise<RepairReport> {
 }
 
 export const replicationRepairCron = new CronJob(config.replication.repairSchedule, () => {
-  if (running) {
-    return
-  }
+  void runScheduledRepair()
+})
+
+let stopping = false
+let continuationTimer: NodeJS.Timeout | undefined
+let scheduledInFlight: Promise<void> | undefined
+
+async function runScheduledRepair(): Promise<void> {
+  if (stopping || running || continuationTimer !== undefined) return
 
   logger.info('[Cron] Running "replicationRepair" cronjob.')
-  repairUnderReplicatedFiles().catch((err) => logger.error(`${err.message}\n${err.stack}`))
-})
+  const run = repairUnderReplicatedFiles()
+    .then((report) => {
+      if (stopping || report.cycleCompleted) return
+      continuationTimer = setTimeout(() => {
+        continuationTimer = undefined
+        void runScheduledRepair()
+      }, config.replication.repairBatchDelayMs)
+      continuationTimer.unref()
+    })
+    .catch((err: Error) => logger.error(`${err.message}\n${err.stack}`))
+  scheduledInFlight = run
+  await run
+  if (scheduledInFlight === run) scheduledInFlight = undefined
+}
+
+/** Start the periodic repair job and immediately begin the first full cycle. */
+export function startReplicationRepair(): void {
+  stopping = false
+  replicationRepairCron.start()
+  void runScheduledRepair()
+}
+
+/** Stop scheduled repair work and wait for the active bounded pass. */
+export async function stopReplicationRepair(): Promise<void> {
+  stopping = true
+  replicationRepairCron.stop()
+  if (continuationTimer !== undefined) clearTimeout(continuationTimer)
+  continuationTimer = undefined
+  await scheduledInFlight
+}
 
 export function getReplicationState() {
   return {
@@ -183,6 +221,7 @@ export function getReplicationState() {
     cycle: evidence
       ? {
           startedAt: evidence.startedAt,
+          examined: evidence.examined,
           checked: evidence.checked,
           underReplicated: evidence.underReplicated,
           repaired: evidence.repaired,
@@ -195,7 +234,9 @@ export function getReplicationState() {
       : null,
     lastRun: lastReport
       ? {
+          examined: lastReport.examined,
           checked: lastReport.checked,
+          releasedChecked: lastReport.releasedChecked,
           underReplicated: lastReport.underReplicated,
           repaired: lastReport.repaired.length,
           stillMissing: lastReport.stillMissing.length,

--- a/src/replication.cron.ts
+++ b/src/replication.cron.ts
@@ -26,6 +26,7 @@ interface RepairCycleEvidence {
   unrecoverable: number
   lastCompletedAt: number | null
   lastCompletedSuccessfully: boolean
+  lastCompletedBacklog: number
 }
 
 let evidence: RepairCycleEvidence | null = null
@@ -45,7 +46,8 @@ function emptyEvidence(now = Date.now()): RepairCycleEvidence {
     stillMissing: 0,
     unrecoverable: 0,
     lastCompletedAt: config.replication.enabled && config.replication.repairEnabled ? null : now,
-    lastCompletedSuccessfully: !config.replication.enabled || !config.replication.repairEnabled
+    lastCompletedSuccessfully: !config.replication.enabled || !config.replication.repairEnabled,
+    lastCompletedBacklog: 0
   }
 }
 
@@ -72,7 +74,8 @@ async function loadEvidence(): Promise<RepairCycleEvidence> {
       Number.isSafeInteger(parsed.stillMissing) &&
       Number.isSafeInteger(parsed.unrecoverable) &&
       (parsed.lastCompletedAt === null || Number.isSafeInteger(parsed.lastCompletedAt)) &&
-      typeof parsed.lastCompletedSuccessfully === 'boolean'
+      typeof parsed.lastCompletedSuccessfully === 'boolean' &&
+      Number.isSafeInteger(parsed.lastCompletedBacklog)
         ? (parsed as RepairCycleEvidence)
         : emptyEvidence()
   } catch (err) {
@@ -133,7 +136,8 @@ export async function repairUnderReplicatedFiles(): Promise<RepairReport> {
         ? {
             ...emptyEvidence(),
             lastCompletedAt: completedAt,
-            lastCompletedSuccessfully: completedSuccessfully
+            lastCompletedSuccessfully: completedSuccessfully,
+            lastCompletedBacklog: aggregate.stillMissing + aggregate.unrecoverable
           }
         : {
             ...current,
@@ -185,7 +189,8 @@ export function getReplicationState() {
           stillMissing: evidence.stillMissing,
           unrecoverable: evidence.unrecoverable,
           lastCompletedAt: evidence.lastCompletedAt,
-          lastCompletedSuccessfully: evidence.lastCompletedSuccessfully
+          lastCompletedSuccessfully: evidence.lastCompletedSuccessfully,
+          lastCompletedBacklog: evidence.lastCompletedBacklog
         }
       : null,
     lastRun: lastReport
@@ -210,13 +215,15 @@ export async function initializeReplicationRepairState(): Promise<void> {
 export function getRepairHealthEvidence(): {
   required: boolean
   completedAt: number | null
+  healthy: boolean
+  backlog: number
 } {
   const required = config.replication.enabled && config.replication.repairEnabled
+  const activeBacklog = (evidence?.stillMissing ?? 0) + (evidence?.unrecoverable ?? 0)
   return {
     required,
-    completedAt:
-      !required || evidence?.lastCompletedSuccessfully === true
-        ? (evidence?.lastCompletedAt ?? Date.now())
-        : null
+    completedAt: evidence?.lastCompletedAt ?? (required ? null : Date.now()),
+    healthy: !required || evidence?.lastCompletedSuccessfully === true,
+    backlog: required ? Math.max(evidence?.lastCompletedBacklog ?? 0, activeBacklog) : 0
   }
 }

--- a/src/storage/config.ts
+++ b/src/storage/config.ts
@@ -43,6 +43,8 @@ export interface StorageConfig {
    * `429` for a person who did nothing wrong.
    */
   maxConcurrentUploads: number
+  /** Maximum number of file responses retrieving content at once. */
+  maxConcurrentDownloads: number
   /** Free space on the blockstore filesystem that uploads must never consume. */
   diskReserveBytes: number
   /** When true, an upload stays temporary until an authorized confirmation. */
@@ -85,11 +87,14 @@ export interface ReplicationConfig {
   repairSchedule: string
   /** Pause between bounded passes while completing one full repair cycle. */
   repairBatchDelayMs: number
+  /** Released records probed concurrently during one repair pass. */
+  repairProbeConcurrency: number
 }
 
 export const DEFAULT_STORAGE_CONFIG: StorageConfig = {
   maxRequestSizeBytes: 512 * MiB,
   maxConcurrentUploads: 32,
+  maxConcurrentDownloads: 64,
   diskReserveBytes: 5 * GiB,
   confirmationRequired: false,
   temporaryTtlMs: 24 * 60 * 60 * 1000,
@@ -113,7 +118,8 @@ export const DEFAULT_REPLICATION_CONFIG: ReplicationConfig = {
   requestTimeoutMs: 30000,
   repairEnabled: true,
   repairSchedule: '0 */30 * * * *',
-  repairBatchDelayMs: 1_000
+  repairBatchDelayMs: 1_000,
+  repairProbeConcurrency: 4
 }
 
 function fail(path: string, expectation: string): never {
@@ -209,6 +215,12 @@ export function resolveStorageConfig(raw: unknown, uploadLimitSizeBytes: number)
       input.maxConcurrentUploads,
       'storage.maxConcurrentUploads',
       defaults.maxConcurrentUploads,
+      1
+    ),
+    maxConcurrentDownloads: optionalInteger(
+      input.maxConcurrentDownloads,
+      'storage.maxConcurrentDownloads',
+      defaults.maxConcurrentDownloads,
       1
     ),
     diskReserveBytes: optionalInteger(
@@ -325,6 +337,12 @@ export function resolveReplicationConfig(raw: unknown): ReplicationConfig {
       'replication.repairBatchDelayMs',
       defaults.repairBatchDelayMs,
       0
+    ),
+    repairProbeConcurrency: optionalInteger(
+      input.repairProbeConcurrency,
+      'replication.repairProbeConcurrency',
+      defaults.repairProbeConcurrency,
+      1
     )
   }
 

--- a/src/storage/config.ts
+++ b/src/storage/config.ts
@@ -83,6 +83,8 @@ export interface ReplicationConfig {
   requestTimeoutMs: number
   repairEnabled: boolean
   repairSchedule: string
+  /** Pause between bounded passes while completing one full repair cycle. */
+  repairBatchDelayMs: number
 }
 
 export const DEFAULT_STORAGE_CONFIG: StorageConfig = {
@@ -110,7 +112,8 @@ export const DEFAULT_REPLICATION_CONFIG: ReplicationConfig = {
   requireQuorumOnUpload: false,
   requestTimeoutMs: 30000,
   repairEnabled: true,
-  repairSchedule: '0 */30 * * * *'
+  repairSchedule: '0 */30 * * * *',
+  repairBatchDelayMs: 1_000
 }
 
 function fail(path: string, expectation: string): never {
@@ -316,6 +319,12 @@ export function resolveReplicationConfig(raw: unknown): ReplicationConfig {
       input.repairSchedule,
       'replication.repairSchedule',
       defaults.repairSchedule
+    ),
+    repairBatchDelayMs: optionalInteger(
+      input.repairBatchDelayMs,
+      'replication.repairBatchDelayMs',
+      defaults.repairBatchDelayMs,
+      0
     )
   }
 

--- a/src/storage/config.ts
+++ b/src/storage/config.ts
@@ -45,6 +45,13 @@ export interface StorageConfig {
   maxConcurrentUploads: number
   /** Maximum number of file responses retrieving content at once. */
   maxConcurrentDownloads: number
+  /**
+   * Share of {@link maxConcurrentDownloads} one client address may hold.
+   *
+   * The global bound protects the node; this one protects everybody else from
+   * a single address holding every slot for the length of its transfers.
+   */
+  maxConcurrentDownloadsPerClient: number
   /** Free space on the blockstore filesystem that uploads must never consume. */
   diskReserveBytes: number
   /** When true, an upload stays temporary until an authorized confirmation. */
@@ -95,6 +102,7 @@ export const DEFAULT_STORAGE_CONFIG: StorageConfig = {
   maxRequestSizeBytes: 512 * MiB,
   maxConcurrentUploads: 32,
   maxConcurrentDownloads: 64,
+  maxConcurrentDownloadsPerClient: 8,
   diskReserveBytes: 5 * GiB,
   confirmationRequired: false,
   temporaryTtlMs: 24 * 60 * 60 * 1000,
@@ -223,6 +231,12 @@ export function resolveStorageConfig(raw: unknown, uploadLimitSizeBytes: number)
       defaults.maxConcurrentDownloads,
       1
     ),
+    maxConcurrentDownloadsPerClient: optionalInteger(
+      input.maxConcurrentDownloadsPerClient,
+      'storage.maxConcurrentDownloadsPerClient',
+      defaults.maxConcurrentDownloadsPerClient,
+      1
+    ),
     diskReserveBytes: optionalInteger(
       input.diskReserveBytes,
       'storage.diskReserveBytes',
@@ -247,6 +261,13 @@ export function resolveStorageConfig(raw: unknown, uploadLimitSizeBytes: number)
     fail(
       'storage.maxRequestSizeBytes',
       'must be greater than or equal to uploadLimitSizeBytes, otherwise no single file can be uploaded'
+    )
+  }
+
+  if (storage.maxConcurrentDownloadsPerClient > storage.maxConcurrentDownloads) {
+    fail(
+      'storage.maxConcurrentDownloadsPerClient',
+      'must not exceed storage.maxConcurrentDownloads, otherwise the per-client share is never applied'
     )
   }
 

--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -1,11 +1,11 @@
 /**
- * Pure upload admission helpers.
+ * Pure storage admission helpers.
  *
  * They are deliberately free of Express, Helia and configuration imports so
  * that every boundary they guard can be exercised in isolation.
  */
 
-/** Counts uploads whose HTTP request has not finished yet. */
+/** Counts operations whose request or transfer has not finished yet. */
 export class ConcurrencyLimiter {
   private inFlight = 0
 

--- a/src/storage/repairCycle.ts
+++ b/src/storage/repairCycle.ts
@@ -24,6 +24,15 @@ export interface RepairCycleBatch {
    * signal that the finished cycle is not evidence about the whole set.
    */
   uncovered: number
+  /**
+   * Whether a completed cycle may be claimed to have covered its candidate set.
+   *
+   * False once a restart resumed the cycle from its persisted cursor: the
+   * rebuilt list cannot tell a record admitted during the downtime from one the
+   * lost passes already visited, so both sit below the cursor and neither shows
+   * up as a late arrival.
+   */
+  coverageProven: boolean
 }
 
 interface RepairCycle {
@@ -32,6 +41,8 @@ interface RepairCycle {
   /** How many of them have been handed out. */
   index: number
   refreshes: number
+  /** The list was rebuilt from a cursor, so its prefix is not proven covered. */
+  resumed: boolean
 }
 
 /**
@@ -100,14 +111,22 @@ export async function nextRepairCycleBatch(
 ): Promise<RepairCycleBatch> {
   if (cycle === undefined || cursor === undefined) {
     const cids = await candidateCids(registry)
-    cycle = { cids, index: resumeIndex(cids, cursor), refreshes: 0 }
+    // Rebuilding from a cursor cannot reconstruct what the lost passes visited.
+    cycle = { cids, index: resumeIndex(cids, cursor), refreshes: 0, resumed: cursor !== undefined }
   }
 
+  const coverageProven = !cycle.resumed
   const batch = cycle.cids.slice(cycle.index, cycle.index + SWEEP_BATCHES.repair)
   cycle.index += batch.length
 
   if (cycle.index < cycle.cids.length) {
-    return { cids: batch, cycleCompleted: false, nextCursor: batch.at(-1) ?? cursor, uncovered: 0 }
+    return {
+      cids: batch,
+      cycleCompleted: false,
+      nextCursor: batch.at(-1) ?? cursor,
+      uncovered: 0,
+      coverageProven
+    }
   }
 
   // End of the committed list. One scan decides whether the cycle covered the
@@ -117,16 +136,22 @@ export async function nextRepairCycleBatch(
 
   if (fresh.length === 0) {
     cycle = undefined
-    return { cids: batch, cycleCompleted: true, uncovered: 0 }
+    return { cids: batch, cycleCompleted: true, uncovered: 0, coverageProven }
   }
 
   if (cycle.refreshes < MAX_CATCH_UP_ROUNDS) {
     cycle.cids.push(...fresh)
     cycle.refreshes += 1
 
-    return { cids: batch, cycleCompleted: false, nextCursor: batch.at(-1) ?? cursor, uncovered: 0 }
+    return {
+      cids: batch,
+      cycleCompleted: false,
+      nextCursor: batch.at(-1) ?? cursor,
+      uncovered: 0,
+      coverageProven
+    }
   }
 
   cycle = undefined
-  return { cids: batch, cycleCompleted: true, uncovered: fresh.length }
+  return { cids: batch, cycleCompleted: true, uncovered: fresh.length, coverageProven }
 }

--- a/src/storage/repairCycle.ts
+++ b/src/storage/repairCycle.ts
@@ -1,0 +1,132 @@
+import { isLifecycleBusy, type FileRecord, type FileRegistry } from './registry.js'
+import { SWEEP_BATCHES } from './sweep.js'
+
+/**
+ * Catch-up rounds a cycle may append before it stops trying to converge.
+ *
+ * Each round only has to cover what arrived during the previous one, so the
+ * work shrinks quickly. The bound is what stops a node under sustained upload
+ * load from extending one cycle indefinitely.
+ */
+const MAX_CATCH_UP_ROUNDS = 3
+
+export interface RepairCycleBatch {
+  /** CIDs this pass should visit, in cycle order. */
+  cids: string[]
+  /** True when this pass ended a cycle, covered or not. */
+  cycleCompleted: boolean
+  /** Cursor to persist so a restart can resume this cycle. */
+  nextCursor?: string
+  /**
+   * Candidates admitted during the cycle that it could not cover.
+   *
+   * Non-zero only when the catch-up rounds ran out, which is the caller's
+   * signal that the finished cycle is not evidence about the whole set.
+   */
+  uncovered: number
+}
+
+interface RepairCycle {
+  /** Candidate CIDs this cycle committed to covering, in visit order. */
+  cids: string[]
+  /** How many of them have been handed out. */
+  index: number
+  refreshes: number
+}
+
+/**
+ * Candidate list of the cycle in progress.
+ *
+ * Held in memory rather than persisted: at production sizes the list is far too
+ * large for a datastore value, and losing it costs one rebuild. A restart
+ * rebuilds it and resumes from the persisted cursor.
+ */
+let cycle: RepairCycle | undefined
+
+/** Forget the cycle in progress, so the next pass starts a new one. */
+export function resetRepairCycle(): void {
+  cycle = undefined
+}
+
+function isCandidate(record: FileRecord): boolean {
+  return record.state === 'confirmed' && !isLifecycleBusy(record)
+}
+
+/** Read the current candidate set, ordered the way a cycle walks it. */
+async function candidateCids(registry: FileRegistry): Promise<string[]> {
+  const cids = (await registry.all()).filter(isCandidate).map((record) => record.cid)
+
+  // Code-unit ordering, matching the cursor comparison in `resumeIndex`.
+  return cids.sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
+}
+
+/** Locate the persisted cursor in a freshly built list, after a restart. */
+function resumeIndex(cids: string[], cursor: string | undefined): number {
+  if (cursor === undefined) {
+    return 0
+  }
+
+  const exact = cids.indexOf(cursor)
+  if (exact >= 0) {
+    return exact + 1
+  }
+
+  // The cursor record left the candidate set. Resume at the first CID strictly
+  // greater so the pass does not rewind to the head.
+  const next = cids.findIndex((cid) => cid > cursor)
+  return next >= 0 ? next : cids.length
+}
+
+/**
+ * Take the next bounded batch of the repair cycle.
+ *
+ * The candidate set is read once per cycle instead of once per pass: a full
+ * cycle over `N` records used to scan and sort the whole registry `N / 50`
+ * times. Slicing a committed list also makes coverage decidable — reaching the
+ * end means every CID the cycle committed to was handed out.
+ *
+ * Records that arrived while the cycle was walking are not in that list, so one
+ * scan at the end names them. They are appended and covered by the same cycle
+ * where possible, because discarding a finished cycle on every upload would
+ * stop `repairFresh` from ever advancing on a busy node.
+ *
+ * @param registry lifecycle registry to read candidates from
+ * @param cursor CID the previous pass stopped at, or `undefined` to start a cycle
+ * @returns the batch, the cycle boundary, and any candidates left uncovered
+ */
+export async function nextRepairCycleBatch(
+  registry: FileRegistry,
+  cursor: string | undefined
+): Promise<RepairCycleBatch> {
+  if (cycle === undefined || cursor === undefined) {
+    const cids = await candidateCids(registry)
+    cycle = { cids, index: resumeIndex(cids, cursor), refreshes: 0 }
+  }
+
+  const batch = cycle.cids.slice(cycle.index, cycle.index + SWEEP_BATCHES.repair)
+  cycle.index += batch.length
+
+  if (cycle.index < cycle.cids.length) {
+    return { cids: batch, cycleCompleted: false, nextCursor: batch.at(-1) ?? cursor, uncovered: 0 }
+  }
+
+  // End of the committed list. One scan decides whether the cycle covered the
+  // set it set out to cover, or whether records arrived behind it.
+  const committed = new Set(cycle.cids)
+  const fresh = (await candidateCids(registry)).filter((cid) => !committed.has(cid))
+
+  if (fresh.length === 0) {
+    cycle = undefined
+    return { cids: batch, cycleCompleted: true, uncovered: 0 }
+  }
+
+  if (cycle.refreshes < MAX_CATCH_UP_ROUNDS) {
+    cycle.cids.push(...fresh)
+    cycle.refreshes += 1
+
+    return { cids: batch, cycleCompleted: false, nextCursor: batch.at(-1) ?? cursor, uncovered: 0 }
+  }
+
+  cycle = undefined
+  return { cids: batch, cycleCompleted: true, uncovered: fresh.length }
+}

--- a/src/storage/repairCycleDriver.ts
+++ b/src/storage/repairCycleDriver.ts
@@ -1,0 +1,98 @@
+export type RepairTrigger = 'startup' | 'schedule' | 'continuation' | 'manual'
+
+export interface RepairPassResult {
+  cycleCompleted: boolean
+}
+
+export interface RepairCycleDriverOptions<T extends RepairPassResult> {
+  delayMs: number
+  runPass: () => Promise<T>
+  busyError: () => Error
+  onStart?: (trigger: RepairTrigger) => void
+  onError?: (error: Error) => void
+}
+
+/** Coordinate scheduled, continued, and manual passes of one repair cycle. */
+export class RepairCycleDriver<T extends RepairPassResult> {
+  private active: Promise<T> | undefined
+  private continuationTimer: NodeJS.Timeout | undefined
+  private stopped = true
+
+  constructor(private readonly options: RepairCycleDriverOptions<T>) {}
+
+  /** Start periodic-cycle ownership and immediately run the first bounded pass. */
+  start(): void {
+    this.stopped = false
+    void this.runAutomatic('startup')
+  }
+
+  /** Start a pass for a cron schedule tick unless a cycle is already continuing. */
+  triggerSchedule(): void {
+    void this.runAutomatic('schedule')
+  }
+
+  /** Run an operator-requested pass through the same continuation driver. */
+  runManual(): Promise<T> {
+    if (this.active !== undefined) return Promise.reject(this.options.busyError())
+    return this.run('manual')
+  }
+
+  /** Stop future passes and wait for the active pass to finish. */
+  async stop(): Promise<void> {
+    this.stopped = true
+    if (this.continuationTimer !== undefined) clearTimeout(this.continuationTimer)
+    this.continuationTimer = undefined
+    await this.active
+  }
+
+  private async runAutomatic(trigger: Exclude<RepairTrigger, 'manual'>): Promise<void> {
+    if (this.stopped) return
+    if (this.continuationTimer !== undefined && trigger !== 'continuation') return
+    if (this.active !== undefined) {
+      if (trigger === 'continuation') this.scheduleContinuation()
+      return
+    }
+
+    try {
+      await this.run(trigger)
+    } catch (error) {
+      this.options.onError?.(error as Error)
+    }
+  }
+
+  private run(trigger: RepairTrigger): Promise<T> {
+    this.options.onStart?.(trigger)
+    const pass = this.options.runPass()
+    this.active = pass
+
+    void pass.then(
+      (report) => {
+        if (report.cycleCompleted) this.cancelContinuation()
+        else this.scheduleContinuation()
+      },
+      () => undefined
+    )
+    void pass.then(this.clearActive(pass), this.clearActive(pass))
+    return pass
+  }
+
+  private clearActive(pass: Promise<T>): () => void {
+    return () => {
+      if (this.active === pass) this.active = undefined
+    }
+  }
+
+  private scheduleContinuation(): void {
+    if (this.stopped || this.continuationTimer !== undefined) return
+    this.continuationTimer = setTimeout(() => {
+      this.continuationTimer = undefined
+      void this.runAutomatic('continuation')
+    }, this.options.delayMs)
+    this.continuationTimer.unref()
+  }
+
+  private cancelContinuation(): void {
+    if (this.continuationTimer !== undefined) clearTimeout(this.continuationTimer)
+    this.continuationTimer = undefined
+  }
+}

--- a/src/storage/repairCycleDriver.ts
+++ b/src/storage/repairCycleDriver.ts
@@ -8,21 +8,35 @@ export interface RepairCycleDriverOptions<T extends RepairPassResult> {
   delayMs: number
   runPass: () => Promise<T>
   busyError: () => Error
+  /** Consecutive failed passes tolerated before the current cycle is given up. */
+  maxConsecutiveFailures?: number
   onStart?: (trigger: RepairTrigger) => void
   onError?: (error: Error) => void
+  /** Reports a cycle ended by repeated failures rather than by completing. */
+  onAbandon?: (error: Error, failures: number) => void
 }
+
+/**
+ * Retries tolerated before a cycle is given up.
+ *
+ * A failed pass is retried because the persisted cursor is untouched, but an
+ * endpoint that keeps failing must not retry every `delayMs` forever.
+ */
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
 
 /** Coordinate scheduled, continued, and manual passes of one repair cycle. */
 export class RepairCycleDriver<T extends RepairPassResult> {
   private active: Promise<T> | undefined
   private continuationTimer: NodeJS.Timeout | undefined
   private stopped = true
+  private consecutiveFailures = 0
 
   constructor(private readonly options: RepairCycleDriverOptions<T>) {}
 
   /** Start periodic-cycle ownership and immediately run the first bounded pass. */
   start(): void {
     this.stopped = false
+    this.consecutiveFailures = 0
     void this.runAutomatic('startup')
   }
 
@@ -31,9 +45,14 @@ export class RepairCycleDriver<T extends RepairPassResult> {
     void this.runAutomatic('schedule')
   }
 
-  /** Run an operator-requested pass through the same continuation driver. */
+  /**
+   * Run an operator-requested pass through the same continuation driver.
+   *
+   * Refused while stopped: a pass admitted after shutdown began would write
+   * cycle evidence that nothing waits for, against a closing datastore.
+   */
   runManual(): Promise<T> {
-    if (this.active !== undefined) return Promise.reject(this.options.busyError())
+    if (this.stopped || this.active !== undefined) return Promise.reject(this.options.busyError())
     return this.run('manual')
   }
 
@@ -61,19 +80,45 @@ export class RepairCycleDriver<T extends RepairPassResult> {
   }
 
   private run(trigger: RepairTrigger): Promise<T> {
+    // Only a continuation inherits the failure budget; every other trigger
+    // takes ownership of the cycle and starts counting again.
+    if (trigger !== 'continuation') this.consecutiveFailures = 0
+
     this.options.onStart?.(trigger)
     const pass = this.options.runPass()
     this.active = pass
 
     void pass.then(
       (report) => {
+        this.consecutiveFailures = 0
         if (report.cycleCompleted) this.cancelContinuation()
         else this.scheduleContinuation()
       },
-      () => undefined
+      (error: Error) => this.onPassFailed(error)
     )
     void pass.then(this.clearActive(pass), this.clearActive(pass))
     return pass
+  }
+
+  /**
+   * Keep a cycle alive across a failed pass.
+   *
+   * The pass wrote no cursor, so a retry resumes exactly where it began.
+   * Dropping the cycle instead costs a whole schedule interval, and
+   * `health.repairMaxAgeMs` is measured from cycle completion, so a transient
+   * datastore error would otherwise be enough to expire node readiness.
+   */
+  private onPassFailed(error: Error): void {
+    this.consecutiveFailures += 1
+
+    const limit = this.options.maxConsecutiveFailures ?? DEFAULT_MAX_CONSECUTIVE_FAILURES
+    if (this.consecutiveFailures >= limit) {
+      this.cancelContinuation()
+      this.options.onAbandon?.(error, this.consecutiveFailures)
+      return
+    }
+
+    this.scheduleContinuation()
   }
 
   private clearActive(pass: Promise<T>): () => void {

--- a/src/storage/repairEvidence.ts
+++ b/src/storage/repairEvidence.ts
@@ -35,14 +35,20 @@ function isCount(value: unknown): value is number {
  * so a future timestamp would read as permanently fresh and let a node with an
  * unverified registry advertise itself as ready.
  *
- * @param parsed value decoded from the datastore
+ * @param value raw value decoded from the datastore, of any shape
  * @param now current time, used to reject state from ahead of the clock
  * @returns the evidence, or `null` when it cannot be trusted
  */
-export function parseEvidence(
-  parsed: Partial<RepairCycleEvidence>,
-  now: number
-): RepairCycleEvidence | null {
+export function parseEvidence(value: unknown, now: number): RepairCycleEvidence | null {
+  // `JSON.parse` legally returns `null` and scalars, and a cast does not change
+  // that at runtime. Reading a field off one would throw out of `loadEvidence`,
+  // whose caller is awaited during startup, so an untrusted payload would stop
+  // the node from starting instead of falling back to an empty cycle.
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null
+  }
+
+  const parsed = value as Partial<RepairCycleEvidence>
   const valid =
     typeof parsed.membershipVersion === 'string' &&
     typeof parsed.policyVersion === 'string' &&

--- a/src/storage/repairEvidence.ts
+++ b/src/storage/repairEvidence.ts
@@ -1,0 +1,77 @@
+/**
+ * Validation of the persisted replication-repair cycle evidence.
+ *
+ * Kept apart from `replication.cron.ts` so the rules can be exercised without
+ * importing a module that starts a Helia node and opens the datastore.
+ */
+
+export interface RepairCycleEvidence {
+  membershipVersion: string
+  policyVersion: string
+  cursor?: string
+  startedAt: number
+  /** The cycle cannot claim to have covered its candidate set. */
+  superseded: boolean
+  examined: number
+  checked: number
+  underReplicated: number
+  repaired: number
+  stillMissing: number
+  unrecoverable: number
+  lastCompletedAt: number | null
+  lastCompletedSuccessfully: boolean
+  lastCompletedBacklog: number
+}
+
+function isCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+/**
+ * Accept only repair evidence this node could have written.
+ *
+ * A negative counter or a completion stamped ahead of the clock is not merely
+ * malformed: `evaluateHealth` measures repair freshness from `lastCompletedAt`,
+ * so a future timestamp would read as permanently fresh and let a node with an
+ * unverified registry advertise itself as ready.
+ *
+ * @param parsed value decoded from the datastore
+ * @param now current time, used to reject state from ahead of the clock
+ * @returns the evidence, or `null` when it cannot be trusted
+ */
+export function parseEvidence(
+  parsed: Partial<RepairCycleEvidence>,
+  now: number
+): RepairCycleEvidence | null {
+  const valid =
+    typeof parsed.membershipVersion === 'string' &&
+    typeof parsed.policyVersion === 'string' &&
+    (parsed.cursor === undefined || typeof parsed.cursor === 'string') &&
+    isCount(parsed.startedAt) &&
+    parsed.startedAt <= now &&
+    (parsed.examined === undefined || isCount(parsed.examined)) &&
+    (parsed.superseded === undefined || typeof parsed.superseded === 'boolean') &&
+    isCount(parsed.checked) &&
+    isCount(parsed.underReplicated) &&
+    isCount(parsed.repaired) &&
+    isCount(parsed.stillMissing) &&
+    isCount(parsed.unrecoverable) &&
+    (parsed.lastCompletedAt === null ||
+      (isCount(parsed.lastCompletedAt) && parsed.lastCompletedAt <= now)) &&
+    typeof parsed.lastCompletedSuccessfully === 'boolean' &&
+    isCount(parsed.lastCompletedBacklog) &&
+    // A cycle cannot have checked more records than it visited, and cannot
+    // report a clean completion while carrying a backlog.
+    parsed.checked <= (parsed.examined ?? parsed.checked) &&
+    (!parsed.lastCompletedSuccessfully || parsed.lastCompletedBacklog === 0)
+
+  if (!valid) {
+    return null
+  }
+
+  return {
+    ...parsed,
+    examined: parsed.examined ?? parsed.checked,
+    superseded: parsed.superseded ?? false
+  } as RepairCycleEvidence
+}

--- a/src/storage/retrieval.ts
+++ b/src/storage/retrieval.ts
@@ -76,7 +76,8 @@ export function retrievalTargets(
 export async function connectToHolders(
   node: IpfsNode,
   targets: ReplicationPeer[],
-  timeoutMs: number = HOLDER_DIAL_TIMEOUT_MS
+  timeoutMs: number = HOLDER_DIAL_TIMEOUT_MS,
+  externalSignal?: AbortSignal
 ): Promise<number> {
   const connected = new Set(node.libp2p.getPeers().map((peer) => peer.toString()))
   const missing = targets.filter((peer) => !connected.has(peer.peerId))
@@ -86,9 +87,13 @@ export async function connectToHolders(
   }
 
   const results = await Promise.allSettled(
-    missing.map(async (peer) =>
-      node.libp2p.dial(peer.multiAddr, { signal: AbortSignal.timeout(timeoutMs) })
-    )
+    missing.map(async (peer) => {
+      const timeoutSignal = AbortSignal.timeout(timeoutMs)
+      const signal = externalSignal
+        ? AbortSignal.any([timeoutSignal, externalSignal])
+        : timeoutSignal
+      return node.libp2p.dial(peer.multiAddr, { signal })
+    })
   )
 
   return results.filter((result) => result.status === 'fulfilled').length
@@ -104,11 +109,12 @@ export async function prepareRetrieval(
   node: IpfsNode,
   cid: CID,
   targets: () => ReplicationPeer[],
-  timeoutMs: number = HOLDER_DIAL_TIMEOUT_MS
+  timeoutMs: number = HOLDER_DIAL_TIMEOUT_MS,
+  signal?: AbortSignal
 ): Promise<void> {
   if (await node.blockstore.has(cid)) {
     return
   }
 
-  await connectToHolders(node, targets(), timeoutMs)
+  await connectToHolders(node, targets(), timeoutMs, signal)
 }

--- a/src/storage/service.ts
+++ b/src/storage/service.ts
@@ -937,7 +937,10 @@ async function rescueOrphanedFiles(
   }
 
   await Promise.all(
-    Array.from({ length: Math.min(4, candidates.length) }, async () => processNext())
+    Array.from(
+      { length: Math.min(config.replication.repairProbeConcurrency, candidates.length) },
+      async () => processNext()
+    )
   )
 
   rescued.sort()

--- a/src/storage/service.ts
+++ b/src/storage/service.ts
@@ -56,7 +56,8 @@ import {
 } from './meter.js'
 import { claimedBytes, claimSpace, type Claim } from './reservation.js'
 import { fileRegistry, incomingCopyLimiter, storageOperationLock } from './state.js'
-import { nextSweepBatch, sweepBatch } from './sweep.js'
+import { nextSweepBatch } from './sweep.js'
+import { nextRepairCycleBatch } from './repairCycle.js'
 import { claimRepairRecord, releaseRepairRecord } from './repairClaim.js'
 
 const callOptions = (): ReplicationCallOptions => ({
@@ -636,7 +637,10 @@ export function createReplicationHandlers(): ReplicationHandlers {
     cacheCopy: cacheFileLocally,
     onError: (message) => logger.warn(message),
     onRefused: (peerId, op) =>
-      logger.info(`Refused "${op}" from an unknown peer ${peerId}; offering a cached copy instead`)
+      logger.info(
+        { event: 'replication_refused_unknown_peer', op },
+        'Refused an operation from an unknown peer; offering a cached copy instead'
+      )
   }
 }
 
@@ -807,6 +811,8 @@ export interface RepairReport {
   unrecoverable: string[]
   /** This pass reached the end of a complete bounded repair cycle. */
   cycleCompleted: boolean
+  /** Candidates admitted during the cycle that its catch-up rounds could not cover. */
+  uncovered: number
   /** Durable resume cursor for the next pass. */
   nextCursor?: string
 }
@@ -875,7 +881,12 @@ async function rescueOrphanedFiles(
 
       if (!(await helia.blockstore.has(cid))) {
         unrecoverable.push(record.cid)
-        logger.error(`No configured node reports holding ${record.cid}`)
+        // The CID stays out of the log; the repair report returns the full
+        // `unrecoverable` list on the authenticated endpoint that asked for it.
+        logger.error(
+          { event: 'replication_unrecoverable_record' },
+          'No configured node holds a confirmed record'
+        )
         continue
       }
 
@@ -928,7 +939,10 @@ async function rescueOrphanedFiles(
         }
 
         rescued.push(record.cid)
-        logger.warn(`No node was holding ${record.cid}; kept the local copy instead`)
+        logger.warn(
+          { event: 'replication_rescued_record' },
+          'No node was holding a confirmed record; kept the local copy'
+        )
       } catch {
         // The blocks are only partly here, so there is nothing to rescue
         continue
@@ -965,7 +979,8 @@ export async function repairReplication(options: { cursor?: string } = {}): Prom
     stillMissing: [],
     rescued: [],
     unrecoverable: [],
-    cycleCompleted: true
+    cycleCompleted: true,
+    uncovered: 0
   }
 
   if (!config.replication.enabled) {
@@ -974,15 +989,17 @@ export async function repairReplication(options: { cursor?: string } = {}): Prom
 
   const peers = getReplicationPeers()
   const self = selfPeerId()
-  const records = await fileRegistry.all()
-  const selected = sweepBatch(
-    'repair',
-    records.filter((record) => record.state === 'confirmed' && !isLifecycleBusy(record)),
-    options.cursor
-  )
-  const candidates = selected.records
+  const selected = await nextRepairCycleBatch(fileRegistry, options.cursor)
   report.cycleCompleted = selected.cycleCompleted
   report.nextCursor = selected.nextCursor
+  report.uncovered = selected.uncovered
+
+  // The cycle committed to these CIDs one scan ago, so each record is read
+  // again here rather than trusted from that list. A record that has since been
+  // released or deleted simply drops out of the pass.
+  const candidates = (
+    await Promise.all(selected.cids.map(async (cid) => fileRegistry.get(cid)))
+  ).filter((record): record is FileRecord => record !== undefined)
 
   report.examined = candidates.length
 
@@ -1155,7 +1172,10 @@ export async function demoteReleasableCopies(
 
     if (demoted) {
       report.demoted.push(record.cid)
-      logger.info(`Released the local copy of ${record.cid}; ${holders.length} peers hold it`)
+      logger.info(
+        { event: 'storage_demoted_record', holders: holders.length },
+        'Released a local copy held by peers'
+      )
     }
   }
 

--- a/src/storage/service.ts
+++ b/src/storage/service.ts
@@ -56,7 +56,7 @@ import {
 } from './meter.js'
 import { claimedBytes, claimSpace, type Claim } from './reservation.js'
 import { fileRegistry, incomingCopyLimiter, storageOperationLock } from './state.js'
-import { nextSweepBatch } from './sweep.js'
+import { nextSweepBatch, sweepBatch } from './sweep.js'
 import { claimRepairRecord, releaseRepairRecord } from './repairClaim.js'
 
 const callOptions = (): ReplicationCallOptions => ({
@@ -282,9 +282,13 @@ export async function replicateFile(cid: string): Promise<ReplicationReport> {
  * not one of its holders. Placement tells it exactly which nodes to reach, so
  * the read does not depend on a holder happening to be connected already.
  */
-export async function prepareFileRetrieval(cid: CID): Promise<void> {
-  await prepareRetrieval(helia, cid, () =>
-    retrievalTargets(cid.toString(), config.replication, selfPeerId(), getReplicationPeers())
+export async function prepareFileRetrieval(cid: CID, signal?: AbortSignal): Promise<void> {
+  await prepareRetrieval(
+    helia,
+    cid,
+    () => retrievalTargets(cid.toString(), config.replication, selfPeerId(), getReplicationPeers()),
+    undefined,
+    signal
   )
 }
 
@@ -794,6 +798,12 @@ export interface RepairReport {
   stillMissing: string[]
   /** Files nobody was found holding, whose local blocks were pinned again. */
   rescued: string[]
+  /** Files no designated peer holds and whose local DAG is no longer complete. */
+  unrecoverable: string[]
+  /** This pass reached the end of a complete bounded repair cycle. */
+  cycleCompleted: boolean
+  /** Durable resume cursor for the next pass. */
+  nextCursor?: string
 }
 
 /** Ask the designated peers which durable copies exist right now. */
@@ -826,23 +836,16 @@ async function liveHolderNames(holders: ReplicationPeer[], cid: string): Promise
 async function rescueOrphanedFiles(
   records: FileRecord[],
   peers: ReplicationPeer[]
-): Promise<string[]> {
+): Promise<{ rescued: string[]; unrecoverable: string[] }> {
   const self = selfPeerId()
   const rescued: string[] = []
+  const unrecoverable: string[] = []
   const byPeerId = new Map(peers.map((peer) => [peer.peerId, peer]))
 
-  const candidates = nextSweepBatch(
-    'rescue',
-    records.filter((record) => record.state === 'confirmed' && !record.heldLocally)
-  )
+  const candidates = records.filter((record) => record.state === 'confirmed' && !record.heldLocally)
 
   for (const record of candidates) {
     const cid = CID.parse(record.cid)
-
-    if (!(await helia.blockstore.has(cid))) {
-      continue
-    }
-
     const holders = storageTargets(placementFor(record.cid, record.createdAt, peers), self)
       .map((peerId) => byPeerId.get(peerId))
       .filter((peer): peer is ReplicationPeer => peer !== undefined)
@@ -858,6 +861,12 @@ async function rescueOrphanedFiles(
     )
 
     if (answers.some(Boolean)) {
+      continue
+    }
+
+    if (!(await helia.blockstore.has(cid))) {
+      unrecoverable.push(record.cid)
+      logger.error(`No configured node reports holding ${record.cid}`)
       continue
     }
 
@@ -917,7 +926,7 @@ async function rescueOrphanedFiles(
     }
   }
 
-  return rescued
+  return { rescued, unrecoverable }
 }
 
 /**
@@ -927,13 +936,15 @@ async function rescueOrphanedFiles(
  * may disappear by policy, and a file this node released is another node's
  * responsibility.
  */
-export async function repairReplication(): Promise<RepairReport> {
+export async function repairReplication(options: { cursor?: string } = {}): Promise<RepairReport> {
   const report: RepairReport = {
     checked: 0,
     underReplicated: 0,
     repaired: [],
     stillMissing: [],
-    rescued: []
+    rescued: [],
+    unrecoverable: [],
+    cycleCompleted: true
   }
 
   if (!config.replication.enabled) {
@@ -943,13 +954,23 @@ export async function repairReplication(): Promise<RepairReport> {
   const peers = getReplicationPeers()
   const self = selfPeerId()
   const records = await fileRegistry.all()
-  const candidates = nextSweepBatch('repair', records.filter(isSettledHeldFile))
+  const selected = sweepBatch(
+    'repair',
+    records.filter((record) => record.state === 'confirmed' && !isLifecycleBusy(record)),
+    options.cursor
+  )
+  const candidates = selected.records
+  report.cycleCompleted = selected.cycleCompleted
+  report.nextCursor = selected.nextCursor
 
   report.checked = candidates.length
 
   const byPeerId = new Map(peers.map((peer) => [peer.peerId, peer]))
 
   for (const record of candidates) {
+    if (!isSettledHeldFile(record)) {
+      continue
+    }
     if (!(await claimRepairRecord(fileRegistry, record))) {
       continue
     }
@@ -988,7 +1009,9 @@ export async function repairReplication(): Promise<RepairReport> {
     }
   }
 
-  report.rescued = await rescueOrphanedFiles(records, peers)
+  const rescue = await rescueOrphanedFiles(candidates, peers)
+  report.rescued = rescue.rescued
+  report.unrecoverable = rescue.unrecoverable
 
   return report
 }

--- a/src/storage/service.ts
+++ b/src/storage/service.ts
@@ -792,7 +792,12 @@ async function cacheFileLocallyUnderLock(cid: string, peerId: string): Promise<n
 }
 
 export interface RepairReport {
+  /** Confirmed records visited by this bounded pass. */
+  examined: number
+  /** Locally held records checked against their placement. */
   checked: number
+  /** Released records checked for a remaining durable holder. */
+  releasedChecked: number
   underReplicated: number
   repaired: string[]
   stillMissing: string[]
@@ -828,105 +833,116 @@ async function liveHolderNames(holders: ReplicationPeer[], cid: string): Promise
  * later left is nobody's responsibility and disappears silently while every
  * registry still calls it confirmed.
  *
- * The check is cheap because it starts with a local lookup: a node can only
- * rescue a file whose blocks it still has, and blocks are kept until space runs
- * short, so shortly after a handover they usually are. Anything already
- * reclaimed is skipped without touching the network.
+ * Peer probes use a small worker pool so a large batch cannot turn one slow
+ * peer into a fully sequential repair pass or fan every record out at once.
  */
 async function rescueOrphanedFiles(
   records: FileRecord[],
   peers: ReplicationPeer[]
-): Promise<{ rescued: string[]; unrecoverable: string[] }> {
+): Promise<{ checked: number; rescued: string[]; unrecoverable: string[] }> {
   const self = selfPeerId()
+  let checked = 0
   const rescued: string[] = []
   const unrecoverable: string[] = []
   const byPeerId = new Map(peers.map((peer) => [peer.peerId, peer]))
 
   const candidates = records.filter((record) => record.state === 'confirmed' && !record.heldLocally)
 
-  for (const record of candidates) {
-    const cid = CID.parse(record.cid)
-    const holders = storageTargets(placementFor(record.cid, record.createdAt, peers), self)
-      .map((peerId) => byPeerId.get(peerId))
-      .filter((peer): peer is ReplicationPeer => peer !== undefined)
+  let nextIndex = 0
+  const processNext = async (): Promise<void> => {
+    while (nextIndex < candidates.length) {
+      const record = candidates[nextIndex]
+      nextIndex += 1
+      checked += 1
+      const cid = CID.parse(record.cid)
+      const holders = storageTargets(placementFor(record.cid, record.createdAt, peers), self)
+        .map((peerId) => byPeerId.get(peerId))
+        .filter((peer): peer is ReplicationPeer => peer !== undefined)
 
-    const answers = await Promise.all(
-      holders.map(async (peer) => {
-        try {
-          return await probeHave(helia, peer.multiAddr, record.cid, callOptions())
-        } catch {
-          return false
-        }
-      })
-    )
-
-    if (answers.some(Boolean)) {
-      continue
-    }
-
-    if (!(await helia.blockstore.has(cid))) {
-      unrecoverable.push(record.cid)
-      logger.error(`No configured node reports holding ${record.cid}`)
-      continue
-    }
-
-    try {
-      const kept = await storageOperationLock.withShared(async () => {
-        // Only worth pinning if the whole DAG is still here; an offline stat says
-        // so without going near the network. Collection cannot invalidate that
-        // result before the following pin is committed.
-        await ifs.stat(cid, { extended: true, offline: true })
-
-        // The record was chosen before the probes, which take as long as the
-        // network does. Writing the snapshot back would undo whatever happened to
-        // the file meanwhile — a re-upload, a release, an updated replica list —
-        // so the pin and the state change happen together, against the record as
-        // it is now.
-        return fileRegistry.withExclusiveCids([record.cid], async (registry) => {
-          const current = await registry.get(record.cid)
-
-          if (
-            current === undefined ||
-            current.revision !== record.revision ||
-            current.state !== 'confirmed' ||
-            current.heldLocally
-          ) {
-            return undefined
-          }
-
-          const createdPin = await pinFile(helia, cid)
-
+      const answers = await Promise.all(
+        holders.map(async (peer) => {
           try {
-            return await registry.save({
-              ...current,
-              pinned: true,
-              heldLocally: true,
-              admissionId: undefined,
-              admissionSettledAt: undefined,
-              replicaStage: undefined
-            })
-          } catch (err) {
-            if (createdPin && current.pinned !== true) {
-              await unpinFile(helia, cid)
-            }
-            throw err
+            return await probeHave(helia, peer.multiAddr, record.cid, callOptions())
+          } catch {
+            return false
           }
         })
-      })
+      )
 
-      if (kept === undefined) {
+      if (answers.some(Boolean)) {
         continue
       }
 
-      rescued.push(record.cid)
-      logger.warn(`No node was holding ${record.cid}; kept the local copy instead`)
-    } catch {
-      // The blocks are only partly here, so there is nothing to rescue
-      continue
+      if (!(await helia.blockstore.has(cid))) {
+        unrecoverable.push(record.cid)
+        logger.error(`No configured node reports holding ${record.cid}`)
+        continue
+      }
+
+      try {
+        const kept = await storageOperationLock.withShared(async () => {
+          // Only worth pinning if the whole DAG is still here; an offline stat says
+          // so without going near the network. Collection cannot invalidate that
+          // result before the following pin is committed.
+          await ifs.stat(cid, { extended: true, offline: true })
+
+          // The record was chosen before the probes, which take as long as the
+          // network does. Writing the snapshot back would undo whatever happened to
+          // the file meanwhile — a re-upload, a release, an updated replica list —
+          // so the pin and the state change happen together, against the record as
+          // it is now.
+          return fileRegistry.withExclusiveCids([record.cid], async (registry) => {
+            const current = await registry.get(record.cid)
+
+            if (
+              current === undefined ||
+              current.revision !== record.revision ||
+              current.state !== 'confirmed' ||
+              current.heldLocally
+            ) {
+              return undefined
+            }
+
+            const createdPin = await pinFile(helia, cid)
+
+            try {
+              return await registry.save({
+                ...current,
+                pinned: true,
+                heldLocally: true,
+                admissionId: undefined,
+                admissionSettledAt: undefined,
+                replicaStage: undefined
+              })
+            } catch (err) {
+              if (createdPin && current.pinned !== true) {
+                await unpinFile(helia, cid)
+              }
+              throw err
+            }
+          })
+        })
+
+        if (kept === undefined) {
+          continue
+        }
+
+        rescued.push(record.cid)
+        logger.warn(`No node was holding ${record.cid}; kept the local copy instead`)
+      } catch {
+        // The blocks are only partly here, so there is nothing to rescue
+        continue
+      }
     }
   }
 
-  return { rescued, unrecoverable }
+  await Promise.all(
+    Array.from({ length: Math.min(4, candidates.length) }, async () => processNext())
+  )
+
+  rescued.sort()
+  unrecoverable.sort()
+  return { checked, rescued, unrecoverable }
 }
 
 /**
@@ -938,7 +954,9 @@ async function rescueOrphanedFiles(
  */
 export async function repairReplication(options: { cursor?: string } = {}): Promise<RepairReport> {
   const report: RepairReport = {
+    examined: 0,
     checked: 0,
+    releasedChecked: 0,
     underReplicated: 0,
     repaired: [],
     stillMissing: [],
@@ -963,7 +981,7 @@ export async function repairReplication(options: { cursor?: string } = {}): Prom
   report.cycleCompleted = selected.cycleCompleted
   report.nextCursor = selected.nextCursor
 
-  report.checked = candidates.length
+  report.examined = candidates.length
 
   const byPeerId = new Map(peers.map((peer) => [peer.peerId, peer]))
 
@@ -974,6 +992,7 @@ export async function repairReplication(options: { cursor?: string } = {}): Prom
     if (!(await claimRepairRecord(fileRegistry, record))) {
       continue
     }
+    report.checked += 1
 
     try {
       const placement = placementFor(record.cid, record.createdAt, peers)
@@ -1010,6 +1029,7 @@ export async function repairReplication(options: { cursor?: string } = {}): Prom
   }
 
   const rescue = await rescueOrphanedFiles(candidates, peers)
+  report.releasedChecked = rescue.checked
   report.rescued = rescue.rescued
   report.unrecoverable = rescue.unrecoverable
 

--- a/src/storage/service.ts
+++ b/src/storage/service.ts
@@ -813,6 +813,8 @@ export interface RepairReport {
   cycleCompleted: boolean
   /** Candidates admitted during the cycle that its catch-up rounds could not cover. */
   uncovered: number
+  /** Whether a completed cycle may be claimed to have covered its candidate set. */
+  coverageProven: boolean
   /** Durable resume cursor for the next pass. */
   nextCursor?: string
 }
@@ -980,7 +982,8 @@ export async function repairReplication(options: { cursor?: string } = {}): Prom
     rescued: [],
     unrecoverable: [],
     cycleCompleted: true,
-    uncovered: 0
+    uncovered: 0,
+    coverageProven: true
   }
 
   if (!config.replication.enabled) {
@@ -993,6 +996,7 @@ export async function repairReplication(options: { cursor?: string } = {}): Prom
   report.cycleCompleted = selected.cycleCompleted
   report.nextCursor = selected.nextCursor
   report.uncovered = selected.uncovered
+  report.coverageProven = selected.coverageProven
 
   // The cycle committed to these CIDs one scan ago, so each record is read
   // again here rather than trusted from that list. A record that has since been

--- a/src/storage/state.ts
+++ b/src/storage/state.ts
@@ -52,3 +52,31 @@ export const COPY_INTAKE_FLOOR = 4
 export const incomingCopyLimiter = new ConcurrencyLimiter(
   Math.max(COPY_INTAKE_FLOOR, Math.floor(config.storage.maxConcurrentUploads / COPY_INTAKE_SHARE))
 )
+
+/** Occupancy of each admission limiter. */
+export interface ConcurrencyMetrics {
+  uploads: { active: number; limit: number }
+  incomingCopies: { active: number; limit: number }
+  downloads: { active: number; limit: number; perClientLimit: number }
+}
+
+/**
+ * Report how full the admission limiters are.
+ *
+ * A limiter refusal and a rate-limit refusal are both `429`, so without the
+ * occupancy an operator cannot tell a client that requests too fast from a
+ * node that has run out of slots — opposite responses. Kept off the public
+ * storage report because it describes node capacity, like the byte-accurate
+ * figures on `GET /api/node/details`.
+ */
+export function getConcurrencyMetrics(): ConcurrencyMetrics {
+  return {
+    uploads: { active: uploadLimiter.active, limit: uploadLimiter.limit },
+    incomingCopies: { active: incomingCopyLimiter.active, limit: incomingCopyLimiter.limit },
+    downloads: {
+      active: downloadLimiter.active,
+      limit: downloadLimiter.limit,
+      perClientLimit: config.storage.maxConcurrentDownloadsPerClient
+    }
+  }
+}

--- a/src/storage/state.ts
+++ b/src/storage/state.ts
@@ -16,6 +16,9 @@ export const storageOperationLock = new StorageOperationLock()
 /** Guards how many uploads may write into the blockstore at the same time. */
 export const uploadLimiter = new ConcurrencyLimiter(config.storage.maxConcurrentUploads)
 
+/** Guards how many public downloads may hold a socket and UnixFS iterator. */
+export const downloadLimiter = new ConcurrencyLimiter(config.storage.maxConcurrentDownloads)
+
 /**
  * Share of the upload limit that incoming copies may occupy.
  *

--- a/src/storage/sweep.ts
+++ b/src/storage/sweep.ts
@@ -25,7 +25,15 @@ export interface SweepBatch<T> {
  *
  * A persisted cursor may be supplied after restart. A batch never mixes the
  * tail of one cycle with the head of the next, so completing a batch proves
- * that every candidate present in that ordered cycle was visited.
+ * that every candidate present **when the cycle began** was visited: CIDs are
+ * immutable, so a record that existed then either sorts before the cursor and
+ * was already visited, or sorts after it and still will be.
+ *
+ * It proves nothing about records admitted mid-cycle. One that sorts before the
+ * current cursor is not visited until the next cycle, which is the right cost:
+ * binding completion to a generation of the candidate set would stop a node
+ * with steady uploads from ever completing a cycle, and repair freshness gates
+ * node health.
  */
 export function sweepBatch<T extends { cid: string }>(
   sweep: SweepName,

--- a/src/storage/sweep.ts
+++ b/src/storage/sweep.ts
@@ -12,6 +12,53 @@ export type SweepName = keyof typeof SWEEP_BATCHES
 /** Where each sweep stopped last time, so the next pass continues from there. */
 const cursors = new Map<SweepName, string>()
 
+export interface SweepBatch<T> {
+  records: T[]
+  /** True when this batch reached the end of one complete sorted sweep. */
+  cycleCompleted: boolean
+  /** Cursor to persist for the next pass; absent after a completed cycle. */
+  nextCursor?: string
+}
+
+/**
+ * Select one non-wrapping batch and expose its cycle boundary.
+ *
+ * A persisted cursor may be supplied after restart. A batch never mixes the
+ * tail of one cycle with the head of the next, so completing a batch proves
+ * that every candidate present in that ordered cycle was visited.
+ */
+export function sweepBatch<T extends { cid: string }>(
+  sweep: SweepName,
+  records: T[],
+  cursor?: string
+): SweepBatch<T> {
+  const size = SWEEP_BATCHES[sweep]
+  const ordered = [...records].sort((left, right) => left.cid.localeCompare(right.cid))
+  let start = 0
+
+  if (cursor !== undefined) {
+    const exact = ordered.findIndex((item) => item.cid === cursor)
+    if (exact >= 0) {
+      start = exact + 1
+    } else {
+      const next = ordered.findIndex((item) => item.cid > cursor)
+      start = next >= 0 ? next : ordered.length
+    }
+  }
+
+  if (start >= ordered.length) {
+    return { records: [], cycleCompleted: true }
+  }
+
+  const batch = ordered.slice(start, start + size)
+  const cycleCompleted = start + batch.length >= ordered.length
+  return {
+    records: batch,
+    cycleCompleted,
+    nextCursor: cycleCompleted ? undefined : batch.at(-1)?.cid
+  }
+}
+
 /**
  * Take the next batch of a periodic sweep, continuing where it left off.
  *
@@ -32,49 +79,22 @@ export function nextSweepBatch<T extends { cid: string }>(
   records: T[],
   options: { advance?: boolean } = {}
 ): T[] {
-  const size = SWEEP_BATCHES[sweep]
   const advance = options.advance !== false
-  const ordered = [...records].sort((left, right) => {
-    if (left.cid === right.cid) {
-      return 0
-    }
+  let selected = sweepBatch(sweep, records, cursors.get(sweep))
 
-    return left.cid < right.cid ? -1 : 1
-  })
-
-  if (ordered.length <= size) {
-    if (advance) {
-      cursors.delete(sweep)
-    }
-
-    return ordered
+  // The prior cursor can sort after every current candidate when records were
+  // deleted or replaced. Start a new cycle instead of returning an empty pass.
+  if (selected.records.length === 0 && records.length > 0) {
+    selected = sweepBatch(sweep, records)
   }
-
-  const previous = cursors.get(sweep)
-  let start = 0
-
-  if (previous !== undefined) {
-    const exact = ordered.findIndex((item) => item.cid === previous)
-    if (exact >= 0) {
-      start = exact + 1
-    } else {
-      // The cursor record left the candidate set (the usual success path for
-      // demote/rescue). Resume at the first CID strictly greater so the pass
-      // does not rewind to the head.
-      const next = ordered.findIndex((item) => item.cid > previous)
-      start = next >= 0 ? next : 0
-    }
-  }
-
-  if (start >= ordered.length) {
-    start = 0
-  }
-
-  const batch = [...ordered.slice(start), ...ordered.slice(0, start)].slice(0, size)
 
   if (advance) {
-    cursors.set(sweep, batch[batch.length - 1].cid)
+    if (selected.nextCursor === undefined) {
+      cursors.delete(sweep)
+    } else {
+      cursors.set(sweep, selected.nextCursor)
+    }
   }
 
-  return batch
+  return selected.records
 }

--- a/src/storage/sweep.ts
+++ b/src/storage/sweep.ts
@@ -5,7 +5,7 @@
  * records into a source of steady chatter. Repair may transfer a file, so it
  * gets the smallest batch; the others only exchange short messages.
  */
-export const SWEEP_BATCHES = { repair: 50, demote: 200, rescue: 50 }
+export const SWEEP_BATCHES = { repair: 50, demote: 200 }
 
 export type SweepName = keyof typeof SWEEP_BATCHES
 
@@ -33,7 +33,11 @@ export function sweepBatch<T extends { cid: string }>(
   cursor?: string
 ): SweepBatch<T> {
   const size = SWEEP_BATCHES[sweep]
-  const ordered = [...records].sort((left, right) => left.cid.localeCompare(right.cid))
+  // Cursor lookup below uses JavaScript code-unit ordering. Keep sorting on the
+  // same deterministic relation instead of the host's locale-dependent ICU rules.
+  const ordered = [...records].sort((left, right) =>
+    left.cid < right.cid ? -1 : left.cid > right.cid ? 1 : 0
+  )
   let start = 0
 
   if (cursor !== undefined) {
@@ -67,7 +71,7 @@ export function sweepBatch<T extends { cid: string }>(
  * it. Candidates are sorted by CID first: resume compares CIDs lexicographically,
  * and datastore listing order is not sorted. A cursor pointing at a record that
  * has since gone resumes at the first remaining CID greater than it, so a
- * successful demote/rescue of the last batch element does not rewind to the head.
+ * successful demotion of the last batch element does not rewind to the head.
  *
  * @param sweep Which sweep is asking; each keeps its own position
  * @param records Every candidate; order is ignored and replaced by CID order

--- a/src/storage/sweep.ts
+++ b/src/storage/sweep.ts
@@ -1,9 +1,9 @@
 /**
  * How many files each periodic sweep looks at per pass.
  *
- * Every sweep asks peers something, so an unbounded one turns a node with many
- * records into a source of steady chatter. Repair may transfer a file, so it
- * gets the smallest batch; the others only exchange short messages.
+ * The batch caps memory, fan-out, and work claimed by one pass. Repair chains
+ * passes until a cycle completes; `repairBatchDelayMs` and probe concurrency
+ * separately control its sustained peer traffic.
  */
 export const SWEEP_BATCHES = { repair: 50, demote: 200 }
 

--- a/src/storage/sweep.ts
+++ b/src/storage/sweep.ts
@@ -29,11 +29,14 @@ export interface SweepBatch<T> {
  * immutable, so a record that existed then either sorts before the cursor and
  * was already visited, or sorts after it and still will be.
  *
- * It proves nothing about records admitted mid-cycle. One that sorts before the
- * current cursor is not visited until the next cycle, which is the right cost:
- * binding completion to a generation of the candidate set would stop a node
- * with steady uploads from ever completing a cycle, and repair freshness gates
- * node health.
+ * It proves nothing about records admitted mid-cycle. Replication repair needs
+ * that guarantee and tracks it in `repairCycle.ts`, which commits to a candidate
+ * list once and reports what arrived behind it; this sweep stays the simple
+ * position-keeping used by demotion.
+ *
+ * @param sweep which sweep is asking; selects the batch size
+ * @param records every current candidate
+ * @param cursor CID the previous pass of this cycle stopped at
  */
 export function sweepBatch<T extends { cid: string }>(
   sweep: SweepName,

--- a/src/utils/downloadResponse.ts
+++ b/src/utils/downloadResponse.ts
@@ -15,14 +15,17 @@ export type DownloadMetadata = {
  * @param metadata CID and expected byte length
  * @param next Express error callback for failures before streaming starts
  * @param onLateError logger callback for failures after response bytes start
+ * @param onDisconnect cancels the underlying retrieval when the client leaves
  */
 export function sendDownloadStream(
   stream: Readable,
   res: Response,
   metadata: DownloadMetadata,
   next: NextFunction,
-  onLateError: (error: Error) => void
+  onLateError: (error: Error) => void,
+  onDisconnect: () => void = () => undefined
 ): void {
+  let clientDisconnected = false
   const setDownloadHeaders = (): void => {
     if (res.headersSent) {
       return
@@ -32,18 +35,31 @@ export function sendDownloadStream(
     res.set('Content-Length', metadata.fileSize.toString())
     res.set('Content-Disposition', `attachment; filename="${metadata.cid}"`)
     res.set('X-Content-Type-Options', 'nosniff')
+    res.set('ETag', `"${metadata.cid}"`)
+    res.set('Cache-Control', 'public, max-age=31536000, immutable')
+    res.set('Accept-Ranges', 'none')
   }
 
   stream.once('data', setDownloadHeaders)
   stream.once('end', setDownloadHeaders)
   stream.once('error', (error: Error) => {
     stream.unpipe(res)
+    if (clientDisconnected) {
+      return
+    }
     if (res.headersSent) {
       onLateError(error)
       res.destroy(error)
       return
     }
     next(error)
+  })
+
+  res.once('close', () => {
+    if (res.writableEnded) return
+    clientDisconnected = true
+    onDisconnect()
+    stream.destroy(new Error('Download client disconnected'))
   })
 
   stream.pipe(res)

--- a/src/utils/downloadResponse.ts
+++ b/src/utils/downloadResponse.ts
@@ -6,6 +6,31 @@ export type DownloadMetadata = {
   fileSize: bigint
 }
 
+/** Match a request validator against the strong CID ETag emitted by this node. */
+export function matchesDownloadEtag(value: string | undefined, cid: string): boolean {
+  if (value === undefined) return false
+  const expected = `"${cid}"`
+  return value
+    .split(',')
+    .map((candidate) => candidate.trim().replace(/^W\//, ''))
+    .some((candidate) => candidate === '*' || candidate === expected)
+}
+
+/** Apply the stable cache and content negotiation headers for a CID response. */
+export function setDownloadHeaders(res: Response, metadata: DownloadMetadata): void {
+  if (res.headersSent) return
+
+  res.set('Content-Type', 'application/octet-stream')
+  res.set('Content-Length', metadata.fileSize.toString())
+  res.set('Content-Disposition', `attachment; filename="${metadata.cid}"`)
+  res.set('X-Content-Type-Options', 'nosniff')
+  res.set('ETag', `"${metadata.cid}"`)
+  // Files may be explicitly released, so shared immutable caching would outlive
+  // the node's serving policy. Private caches revalidate after a bounded hour.
+  res.set('Cache-Control', 'private, max-age=3600, must-revalidate')
+  res.set('Accept-Ranges', 'none')
+}
+
 /**
  * Pipe a file stream while preserving a controlled JSON error response before
  * the first byte and terminating an incomplete binary response afterwards.
@@ -26,22 +51,10 @@ export function sendDownloadStream(
   onDisconnect: () => void = () => undefined
 ): void {
   let clientDisconnected = false
-  const setDownloadHeaders = (): void => {
-    if (res.headersSent) {
-      return
-    }
+  const applyHeaders = (): void => setDownloadHeaders(res, metadata)
 
-    res.set('Content-Type', 'application/octet-stream')
-    res.set('Content-Length', metadata.fileSize.toString())
-    res.set('Content-Disposition', `attachment; filename="${metadata.cid}"`)
-    res.set('X-Content-Type-Options', 'nosniff')
-    res.set('ETag', `"${metadata.cid}"`)
-    res.set('Cache-Control', 'public, max-age=31536000, immutable')
-    res.set('Accept-Ranges', 'none')
-  }
-
-  stream.once('data', setDownloadHeaders)
-  stream.once('end', setDownloadHeaders)
+  stream.once('data', applyHeaders)
+  stream.once('end', applyHeaders)
   stream.once('error', (error: Error) => {
     stream.unpipe(res)
     if (clientDisconnected) {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -22,7 +22,8 @@ export async function getFileStats(cid: CID, externalSignal?: AbortSignal) {
       : abortController.signal
     const stats = await ifs.stat(cid, { signal })
     return stats
-  } catch {
+  } catch (error) {
+    if (externalSignal?.aborted) throw externalSignal.reason ?? error
     throw new FileNotFoundError('Cannot find requested CID. Request timed out.')
   } finally {
     if (timeout !== undefined) {
@@ -32,16 +33,29 @@ export async function getFileStats(cid: CID, externalSignal?: AbortSignal) {
 }
 
 /**
- * Return a file stream by CID.
- * Throws a timeout error if the file is not found.
+ * Return a file stream with idle and size-aware complete-transfer deadlines.
+ *
+ * @param cid Content identifier to retrieve
+ * @param fileSize Stat result used to derive a deadline that permits large active transfers
+ * @param options Request cancellation and test/operator timeout overrides
  */
 export function downloadFile(
   cid: CID,
-  options: { signal?: AbortSignal; timeoutMs?: number } = {}
+  fileSize: bigint,
+  options: { signal?: AbortSignal; idleTimeoutMs?: number; totalTimeoutMs?: number } = {}
 ): TimedReadable {
+  const idleTimeoutMs = options.idleTimeoutMs ?? config.downloadIdleTimeout
+  const sizeAwareTimeoutMs =
+    Math.ceil(Number(fileSize) / config.downloadMinBytesPerSecond) * 1_000 + idleTimeoutMs
+
   return createTimedReadable(
     (signal) => ifs.cat(cid, { signal }),
-    options.timeoutMs ?? config.findFileTimeout,
+    {
+      idleTimeoutMs,
+      totalTimeoutMs:
+        options.totalTimeoutMs ??
+        Math.min(2_147_483_647, Math.max(idleTimeoutMs, sizeAwareTimeoutMs))
+    },
     () => new FileNotFoundError('Unable to retrieve the file. Request timed out.'),
     options.signal
   )

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,15 +1,15 @@
 import { CID } from 'multiformats/cid'
-import { Readable } from 'node:stream'
 import { clearTimeout } from 'node:timers'
 import { config } from '../config.js'
 import { ifs } from '../helia.js'
 import { FileNotFoundError } from './fileErrors.js'
+import { createTimedReadable, type TimedReadable } from './timedStream.js'
 
 /**
  * Return file statistics by CID.
  * Throws a timeout error if the file is not found.
  */
-export async function getFileStats(cid: CID) {
+export async function getFileStats(cid: CID, externalSignal?: AbortSignal) {
   let timeout: NodeJS.Timeout | undefined
   try {
     const abortController = new AbortController()
@@ -17,7 +17,10 @@ export async function getFileStats(cid: CID) {
       abortController.abort(new Error('Cannot find requested CID. Request timed out.'))
     }, config.findFileTimeout)
 
-    const stats = await ifs.stat(cid, { signal: abortController.signal })
+    const signal = externalSignal
+      ? AbortSignal.any([abortController.signal, externalSignal])
+      : abortController.signal
+    const stats = await ifs.stat(cid, { signal })
     return stats
   } catch {
     throw new FileNotFoundError('Cannot find requested CID. Request timed out.')
@@ -32,35 +35,14 @@ export async function getFileStats(cid: CID) {
  * Return a file stream by CID.
  * Throws a timeout error if the file is not found.
  */
-export function downloadFile(cid: CID) {
-  const abortController = new AbortController()
-
-  let aborted = false
-  const abort = () => {
-    if (aborted) return
-
-    aborted = true
-    abortController.abort(new FileNotFoundError('Unable to retrieve the file. Request timed out.'))
-  }
-  const abortTimer = setTimeout(abort, config.findFileTimeout)
-
-  const stream = Readable.from(
-    ifs.cat(cid, {
-      signal: abortController.signal
-    })
+export function downloadFile(
+  cid: CID,
+  options: { signal?: AbortSignal; timeoutMs?: number } = {}
+): TimedReadable {
+  return createTimedReadable(
+    (signal) => ifs.cat(cid, { signal }),
+    options.timeoutMs ?? config.findFileTimeout,
+    () => new FileNotFoundError('Unable to retrieve the file. Request timed out.'),
+    options.signal
   )
-  stream.on('data', () => {
-    clearTimeout(abortTimer)
-  })
-  stream.on('end', () => {
-    clearTimeout(abortTimer)
-  })
-  stream.on('error', () => {
-    clearTimeout(abortTimer)
-  })
-  stream.on('close', () => {
-    clearTimeout(abortTimer)
-  })
-
-  return stream
 }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -54,7 +54,11 @@ export function downloadFile(
       idleTimeoutMs,
       totalTimeoutMs:
         options.totalTimeoutMs ??
-        Math.min(2_147_483_647, Math.max(idleTimeoutMs, sizeAwareTimeoutMs))
+        Math.min(
+          2_147_483_647,
+          config.downloadMaxDurationMs,
+          Math.max(idleTimeoutMs, sizeAwareTimeoutMs)
+        )
     },
     () => new FileNotFoundError('Unable to retrieve the file. Request timed out.'),
     options.signal

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,4 @@
+import { CID } from 'multiformats/cid'
 import { pino } from 'pino'
 import type { DestinationStream, LogFn, Logger } from 'pino'
 import { pinoHttp } from 'pino-http'
@@ -70,10 +71,31 @@ export function routeShape(url: string | undefined): string {
 const LOG_SCRUBBERS: Array<[RegExp, string]> = [
   [/\/(?:ip4|ip6|dns|dns4|dns6|dnsaddr)\/[^\s"',)]+/g, '[multiaddr]'],
   [/\b12D3Koo[1-9A-HJ-NP-Za-km-z]{40,}\b/g, '[peer]'],
-  [/\bQm[1-9A-HJ-NP-Za-km-z]{44}\b/g, '[cid]'],
-  [/\bb[a-z2-7]{58,}\b/g, '[cid]'],
   [/\n\s+at\s+[\s\S]*$/, ' [stack omitted]']
 ]
+
+/**
+ * Tokens shaped like an encoded CID, by multibase prefix.
+ *
+ * A length threshold alone would miss short forms — an identity multihash such
+ * as `bafkqad3qojuxmylumuqhaylznrxwcza` is 32 characters — and lowering it would
+ * start matching ordinary words. Each match is confirmed by the parser instead,
+ * so the shape only has to be cheap enough to skip prose.
+ */
+const CID_CANDIDATE =
+  /\b(?:b[a-z2-7]{15,}|B[A-Z2-7]{15,}|z[1-9A-HJ-NP-Za-km-z]{15,}|f[0-9a-f]{15,}|Qm[1-9A-HJ-NP-Za-km-z]{44})\b/g
+
+/** Replace every token the CID parser accepts, whatever its version or encoding. */
+function scrubCids(value: string): string {
+  return value.replace(CID_CANDIDATE, (token) => {
+    try {
+      CID.parse(token)
+      return '[cid]'
+    } catch {
+      return token
+    }
+  })
+}
 
 /**
  * Remove content identifiers, peer identities, and stack traces from a message.
@@ -87,11 +109,14 @@ const LOG_SCRUBBERS: Array<[RegExp, string]> = [
  * @returns the same text with every identifier replaced by a fixed placeholder
  */
 export function scrubLogValue(value: string): string {
-  return LOG_SCRUBBERS.reduce((text, [pattern, placeholder]) => {
+  const scrubbed = LOG_SCRUBBERS.reduce((text, [pattern, placeholder]) => {
     // A global regex carries `lastIndex` between calls; reset before reuse.
     pattern.lastIndex = 0
     return text.replace(pattern, placeholder)
   }, value)
+
+  CID_CANDIDATE.lastIndex = 0
+  return scrubCids(scrubbed)
 }
 
 /** Apply {@link scrubLogValue} through the strings of one log argument. */

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -77,13 +77,14 @@ const LOG_SCRUBBERS: Array<[RegExp, string]> = [
 /**
  * Tokens shaped like an encoded CID, by multibase prefix.
  *
- * A length threshold alone would miss short forms — an identity multihash such
- * as `bafkqad3qojuxmylumuqhaylznrxwcza` is 32 characters — and lowering it would
- * start matching ordinary words. Each match is confirmed by the parser instead,
- * so the shape only has to be cheap enough to skip prose.
+ * The bounds are the shortest a CID can be, not a guess at what looks like one:
+ * an identity multihash over empty bytes encodes to `bafkqaaa`, eight
+ * characters. Ordinary words are inside these bounds too, which is why the
+ * decision belongs to the parser below rather than to the shape — the shape only
+ * has to be cheap enough that most prose never reaches it.
  */
 const CID_CANDIDATE =
-  /\b(?:b[a-z2-7]{15,}|B[A-Z2-7]{15,}|z[1-9A-HJ-NP-Za-km-z]{15,}|f[0-9a-f]{15,}|Qm[1-9A-HJ-NP-Za-km-z]{44})\b/g
+  /\b(?:b[a-z2-7]{6,}|B[A-Z2-7]{6,}|z[1-9A-HJ-NP-Za-km-z]{6,}|f[0-9a-f]{7,}|Qm[1-9A-HJ-NP-Za-km-z]{44})\b/g
 
 /** Replace every token the CID parser accepts, whatever its version or encoding. */
 function scrubCids(value: string): string {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,19 +5,21 @@ import { config } from '../config.js'
 /**
  * Application logger.
  *
- * `pino-pretty` is loaded as a transport at runtime, so it is a runtime
- * dependency rather than a development one.
+ * Production output is newline-delimited JSON. Pretty output is opt-in because
+ * formatting destroys fields that log collectors use for querying and alerts.
  */
 export const logger = pino({
   level: config.logLevel,
-  transport: {
-    target: 'pino-pretty',
-    options: {
-      colorize: true,
-      translateTime: 'dd.mm.yy HH:MM:ss Z',
-      ignore: 'pid,hostname'
-    }
-  }
+  transport: config.prettyLogs
+    ? {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+          translateTime: 'dd.mm.yy HH:MM:ss Z',
+          ignore: 'pid,hostname'
+        }
+      }
+    : undefined
 })
 
 /**

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,13 +3,81 @@ import { pinoHttp } from 'pino-http'
 import { config } from '../config.js'
 
 /**
+ * Path segments that belong to the API surface rather than to a request.
+ *
+ * Every variable segment of this API is a CID, so anything outside this set is
+ * replaced before a request is logged. A CID identifies stored user content and
+ * has no place in output a collector retains.
+ */
+const ROUTE_SEGMENTS = new Set([
+  'api',
+  'file',
+  'node',
+  'storage',
+  'helia',
+  'libp2p',
+  'debug',
+  'upload',
+  'status',
+  'confirm',
+  'unpin',
+  'health',
+  'info',
+  'details',
+  'metrics',
+  'policy',
+  'gc',
+  'repair',
+  'autopeering',
+  'peers',
+  'pin',
+  'pins',
+  'isPinned'
+])
+
+/**
+ * Reduce a request target to its route shape.
+ *
+ * Drops the query string and masks every segment that is not part of a known
+ * route, so `/api/file/bafy.../status` is logged as `/api/file/:param/status`.
+ *
+ * @param url raw request target
+ * @returns route shape carrying no user-supplied value
+ */
+export function routeShape(url: string | undefined): string {
+  if (url === undefined || url === '') {
+    return '/'
+  }
+
+  const path = url.split('?')[0]
+  const shape = path
+    .split('/')
+    .map((segment) => (segment === '' || ROUTE_SEGMENTS.has(segment) ? segment : ':param'))
+    .join('/')
+
+  return shape === '' ? '/' : shape
+}
+
+/**
  * Application logger.
  *
  * Production output is newline-delimited JSON. Pretty output is opt-in because
  * formatting destroys fields that log collectors use for querying and alerts.
+ *
+ * `redact` is a second line of defense for call sites that log a request or
+ * response object directly; the HTTP serializers below already drop headers.
  */
 export const logger = pino({
   level: config.logLevel,
+  redact: {
+    paths: [
+      'req.headers["x-api-key"]',
+      'req.headers.authorization',
+      'req.headers.cookie',
+      'res.headers["set-cookie"]'
+    ],
+    censor: '[redacted]'
+  },
   transport: config.prettyLogs
     ? {
         target: 'pino-pretty',
@@ -27,8 +95,23 @@ export const logger = pino({
  *
  * Request logs are emitted at `debug` level to keep them out of the default
  * `info` output while still sharing the application logger's transport.
+ *
+ * The default serializers copy every request header and the raw target, which
+ * writes the administrative `x-api-key` verbatim and puts the served CID in the
+ * log — including through the `ETag` and `Content-Disposition` response headers.
+ * Only the method, the route shape, and the status are recorded instead, so the
+ * log level is not the only thing standing between a request and a secret.
  */
+export const httpLogSerializers = {
+  req: (req: { method?: string; url?: string }) => ({
+    method: req.method,
+    url: routeShape(req.url)
+  }),
+  res: (res: { statusCode?: number }) => ({ statusCode: res.statusCode })
+}
+
 export const httpLogger = pinoHttp({
   logger,
-  useLevel: 'debug'
+  useLevel: 'debug',
+  serializers: httpLogSerializers
 })

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import { pino } from 'pino'
+import type { DestinationStream, LogFn, Logger } from 'pino'
 import { pinoHttp } from 'pino-http'
 import { config } from '../config.js'
 
@@ -59,36 +60,134 @@ export function routeShape(url: string | undefined): string {
 }
 
 /**
+ * Values that must never appear in output a collector retains.
+ *
+ * Multiaddrs are matched first because one embeds a peer id, and the stack
+ * pattern last because it is the only multi-line rule. Each entry is anchored
+ * on a shape that cannot occur in prose, so an operational message keeps its
+ * meaning while the identifier inside it does not survive.
+ */
+const LOG_SCRUBBERS: Array<[RegExp, string]> = [
+  [/\/(?:ip4|ip6|dns|dns4|dns6|dnsaddr)\/[^\s"',)]+/g, '[multiaddr]'],
+  [/\b12D3Koo[1-9A-HJ-NP-Za-km-z]{40,}\b/g, '[peer]'],
+  [/\bQm[1-9A-HJ-NP-Za-km-z]{44}\b/g, '[cid]'],
+  [/\bb[a-z2-7]{58,}\b/g, '[cid]'],
+  [/\n\s+at\s+[\s\S]*$/, ' [stack omitted]']
+]
+
+/**
+ * Remove content identifiers, peer identities, and stack traces from a message.
+ *
+ * The HTTP serializers cannot reach these: they sanitize request and response
+ * objects, while most application logging is a template string built at the
+ * call site. Scrubbing centrally means a call site added later cannot reopen
+ * the hole, which a per-site convention would not guarantee.
+ *
+ * @param value message or string field about to be logged
+ * @returns the same text with every identifier replaced by a fixed placeholder
+ */
+export function scrubLogValue(value: string): string {
+  return LOG_SCRUBBERS.reduce((text, [pattern, placeholder]) => {
+    // A global regex carries `lastIndex` between calls; reset before reuse.
+    pattern.lastIndex = 0
+    return text.replace(pattern, placeholder)
+  }, value)
+}
+
+/** Apply {@link scrubLogValue} through the strings of one log argument. */
+function scrubLogArgument(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') {
+    return scrubLogValue(value)
+  }
+
+  // `logger.error(err)` takes the message straight from the error for `msg`,
+  // before any serializer runs, so the error is replaced by a scrubbed copy
+  // rather than passed through. The `err` serializer then drops the stack.
+  if (value instanceof Error) {
+    const scrubbed: Error & { code?: unknown } = new Error(scrubLogValue(value.message))
+    scrubbed.name = value.name
+    const { code } = value as Error & { code?: unknown }
+    if (code !== undefined) {
+      scrubbed.code = code
+    }
+    return scrubbed
+  }
+
+  if (value === null || typeof value !== 'object' || depth > 4) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubLogArgument(item, depth + 1))
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [key, scrubLogArgument(item, depth + 1)])
+  )
+}
+
+/**
  * Application logger.
  *
  * Production output is newline-delimited JSON. Pretty output is opt-in because
  * formatting destroys fields that log collectors use for querying and alerts.
  *
- * `redact` is a second line of defense for call sites that log a request or
- * response object directly; the HTTP serializers below already drop headers.
+ * Three controls keep content and topology out of the output: `hooks.logMethod`
+ * scrubs every message and structured field, the `err` serializer reports an
+ * error without its stack, and `redact` covers call sites that log a request or
+ * response object directly.
  */
-export const logger = pino({
-  level: config.logLevel,
-  redact: {
-    paths: [
-      'req.headers["x-api-key"]',
-      'req.headers.authorization',
-      'req.headers.cookie',
-      'res.headers["set-cookie"]'
-    ],
-    censor: '[redacted]'
-  },
-  transport: config.prettyLogs
-    ? {
-        target: 'pino-pretty',
-        options: {
-          colorize: true,
-          translateTime: 'dd.mm.yy HH:MM:ss Z',
-          ignore: 'pid,hostname'
-        }
+export function createApplicationLogger(
+  options: { level?: string; destination?: DestinationStream } = {}
+): Logger {
+  const level = options.level ?? config.logLevel
+  const shared = {
+    level,
+    hooks: {
+      logMethod(this: Logger, args: unknown[], method: LogFn): void {
+        method.apply(this, args.map((argument) => scrubLogArgument(argument)) as Parameters<LogFn>)
       }
-    : undefined
-})
+    },
+    serializers: {
+      err: (err: Error & { code?: unknown }) => ({
+        type: err.name,
+        message: scrubLogValue(err.message),
+        ...(typeof err.code === 'string' ? { code: err.code } : {})
+      })
+    },
+    redact: {
+      paths: [
+        'req.headers["x-api-key"]',
+        'req.headers.authorization',
+        'req.headers.cookie',
+        'res.headers["set-cookie"]'
+      ],
+      censor: '[redacted]'
+    }
+  }
+
+  // A caller-supplied destination is how the sanitizing wiring is exercised; a
+  // transport would send the records to another thread instead.
+  if (options.destination !== undefined) {
+    return pino(shared, options.destination)
+  }
+
+  return pino({
+    ...shared,
+    transport: config.prettyLogs
+      ? {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'dd.mm.yy HH:MM:ss Z',
+            ignore: 'pid,hostname'
+          }
+        }
+      : undefined
+  })
+}
+
+export const logger = createApplicationLogger()
 
 /**
  * Express middleware that logs requests through {@link logger}.

--- a/src/utils/timedStream.ts
+++ b/src/utils/timedStream.ts
@@ -1,0 +1,48 @@
+import { Readable } from 'node:stream'
+
+export interface TimedReadable {
+  stream: Readable
+  abort: (reason?: Error) => void
+}
+
+/**
+ * Create a readable whose deadline covers the complete iteration.
+ *
+ * The timer is cleared only when the stream ends, errors, or closes. Receiving
+ * a first chunk is deliberately not success: a peer may stall mid-transfer.
+ */
+export function createTimedReadable(
+  source: (signal: AbortSignal) => AsyncIterable<Uint8Array>,
+  timeoutMs: number,
+  timeoutError: () => Error,
+  externalSignal?: AbortSignal
+): TimedReadable {
+  const controller = new AbortController()
+  let aborted = false
+  const abort = (reason = timeoutError()): void => {
+    if (aborted) return
+    aborted = true
+    controller.abort(reason)
+  }
+  const externalAbort = (): void =>
+    abort(
+      externalSignal?.reason instanceof Error
+        ? externalSignal.reason
+        : new Error('Stream request was cancelled')
+    )
+  externalSignal?.addEventListener('abort', externalAbort, { once: true })
+  const timer = setTimeout(abort, timeoutMs)
+  const guardedSource = async function* (): AsyncGenerator<Uint8Array> {
+    if (controller.signal.aborted) throw controller.signal.reason
+    yield* source(controller.signal)
+  }
+  const stream = Readable.from(guardedSource())
+  const cleanup = (): void => {
+    clearTimeout(timer)
+    externalSignal?.removeEventListener('abort', externalAbort)
+  }
+  stream.once('end', cleanup)
+  stream.once('error', cleanup)
+  stream.once('close', cleanup)
+  return { stream, abort }
+}

--- a/src/utils/timedStream.ts
+++ b/src/utils/timedStream.ts
@@ -5,6 +5,13 @@ export interface TimedReadable {
   abort: (reason?: Error) => void
 }
 
+export interface StreamTimeouts {
+  /** Maximum time without receiving another chunk. */
+  idleTimeoutMs: number
+  /** Maximum time for the complete iteration. */
+  totalTimeoutMs: number
+}
+
 /**
  * Create a readable whose deadline covers the complete iteration.
  *
@@ -13,7 +20,7 @@ export interface TimedReadable {
  */
 export function createTimedReadable(
   source: (signal: AbortSignal) => AsyncIterable<Uint8Array>,
-  timeoutMs: number,
+  timeouts: StreamTimeouts,
   timeoutError: () => Error,
   externalSignal?: AbortSignal
 ): TimedReadable {
@@ -30,15 +37,22 @@ export function createTimedReadable(
         ? externalSignal.reason
         : new Error('Stream request was cancelled')
     )
-  externalSignal?.addEventListener('abort', externalAbort, { once: true })
-  const timer = setTimeout(abort, timeoutMs)
+  if (externalSignal?.aborted) externalAbort()
+  else externalSignal?.addEventListener('abort', externalAbort, { once: true })
+  const totalTimer = setTimeout(abort, timeouts.totalTimeoutMs)
+  let idleTimer = setTimeout(abort, timeouts.idleTimeoutMs)
   const guardedSource = async function* (): AsyncGenerator<Uint8Array> {
     if (controller.signal.aborted) throw controller.signal.reason
-    yield* source(controller.signal)
+    for await (const chunk of source(controller.signal)) {
+      clearTimeout(idleTimer)
+      idleTimer = setTimeout(abort, timeouts.idleTimeoutMs)
+      yield chunk
+    }
   }
   const stream = Readable.from(guardedSource())
   const cleanup = (): void => {
-    clearTimeout(timer)
+    clearTimeout(totalTimer)
+    clearTimeout(idleTimer)
     externalSignal?.removeEventListener('abort', externalAbort)
   }
   stream.once('end', cleanup)

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -54,6 +54,7 @@ describe('validateConfig', () => {
     assert.equal(parsed.health.requiredPeerCount, 0)
     assert.equal(parsed.downloadIdleTimeout, 20_000)
     assert.equal(parsed.downloadMinBytesPerSecond, 32 * 1024)
+    assert.equal(parsed.downloadMaxDurationMs, 4 * 60 * 60 * 1_000)
   })
 
   it('ignores unknown keys so deployments can carry extras', () => {
@@ -139,6 +140,13 @@ describe('validateConfig', () => {
         raw.downloadMinBytesPerSecond = 0
       },
       /downloadMinBytesPerSecond/
+    ],
+    [
+      'download maximum duration is below the idle timeout',
+      (raw) => {
+        raw.downloadMaxDurationMs = 1
+      },
+      /downloadMaxDurationMs/
     ]
   ]
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -55,6 +55,7 @@ describe('validateConfig', () => {
     assert.equal(parsed.downloadIdleTimeout, 20_000)
     assert.equal(parsed.downloadMinBytesPerSecond, 32 * 1024)
     assert.equal(parsed.downloadMaxDurationMs, 4 * 60 * 60 * 1_000)
+    assert.equal(parsed.storage.maxConcurrentDownloadsPerClient, 8)
   })
 
   it('ignores unknown keys so deployments can carry extras', () => {
@@ -145,6 +146,14 @@ describe('validateConfig', () => {
       'download maximum duration is below the idle timeout',
       (raw) => {
         raw.downloadMaxDurationMs = 1
+      },
+      /downloadMaxDurationMs/
+    ],
+    [
+      'download ceiling cannot carry the largest permitted file',
+      (raw) => {
+        // 256 MiB at 32 KiB/s needs 8192 s; a one-minute ceiling would cut it off.
+        raw.downloadMaxDurationMs = 60_000
       },
       /downloadMaxDurationMs/
     ]

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -52,6 +52,8 @@ describe('validateConfig', () => {
     assert.equal(parsed.prettyLogs, false)
     assert.equal(parsed.health.checkpointIntervalMs, 60_000)
     assert.equal(parsed.health.requiredPeerCount, 0)
+    assert.equal(parsed.downloadIdleTimeout, 20_000)
+    assert.equal(parsed.downloadMinBytesPerSecond, 32 * 1024)
   })
 
   it('ignores unknown keys so deployments can carry extras', () => {
@@ -123,6 +125,20 @@ describe('validateConfig', () => {
         raw.findFileTimeout = -1
       },
       /findFileTimeout/
+    ],
+    [
+      'download idle timeout is invalid',
+      (raw) => {
+        raw.downloadIdleTimeout = 0
+      },
+      /downloadIdleTimeout/
+    ],
+    [
+      'download minimum throughput is invalid',
+      (raw) => {
+        raw.downloadMinBytesPerSecond = 0
+      },
+      /downloadMinBytesPerSecond/
     ]
   ]
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -49,6 +49,9 @@ describe('validateConfig', () => {
     assert.deepEqual(parsed.peerDiscovery.listen, ['/ip4/0.0.0.0/tcp/4001'])
     assert.deepEqual(parsed.cors.allowedOrigins, ['https://adm.im'])
     assert.equal(parsed.enableDebugApi, false)
+    assert.equal(parsed.prettyLogs, false)
+    assert.equal(parsed.health.checkpointIntervalMs, 60_000)
+    assert.equal(parsed.health.requiredPeerCount, 0)
   })
 
   it('ignores unknown keys so deployments can carry extras', () => {
@@ -164,6 +167,17 @@ describe('validateConfig', () => {
           replication: { ackQuorum: 2, requireQuorumOnUpload: true }
         }),
       /requireQuorumOnUpload/
+    )
+  })
+
+  it('validates health timing and peer coverage', () => {
+    assert.throws(
+      () => validateConfig({ ...validRaw(), health: { checkpointIntervalMs: 999 } }),
+      /health\.checkpointIntervalMs/
+    )
+    assert.throws(
+      () => validateConfig({ ...validRaw(), health: { requiredPeerCount: 1 } }),
+      /health\.requiredPeerCount/
     )
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -58,6 +58,17 @@ describe('validateConfig', () => {
     assert.equal(parsed.storage.maxConcurrentDownloadsPerClient, 8)
   })
 
+  it('keeps a configuration written before the download options valid', () => {
+    // 512 MiB at the fallback 32 KiB/s needs more than the four-hour floor, so
+    // the ceiling has to follow the existing upload limit rather than reject it.
+    const raw = validRaw()
+    raw.uploadLimitSizeBytes = 536_870_912
+    raw.storage = { maxRequestSizeBytes: 536_870_912 }
+    const parsed = validateConfig(raw)
+
+    assert.equal(parsed.downloadMaxDurationMs, Math.ceil(536_870_912 / 32_768) * 1_000 + 20_000)
+  })
+
   it('ignores unknown keys so deployments can carry extras', () => {
     assert.doesNotThrow(() => validateConfig({ ...validRaw(), someFutureOption: 42 }))
   })

--- a/test/downloadAdmission.test.ts
+++ b/test/downloadAdmission.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import type { AddressInfo } from 'node:net'
+import { after, before, describe, it } from 'node:test'
+import express from 'express'
+import { createDownloadAdmission } from '../src/middleware/downloadAdmission.js'
+import { ConcurrencyLimiter } from '../src/storage/limits.js'
+
+describe('download concurrency admission', () => {
+  let url = ''
+  let close: (() => Promise<void>) | undefined
+  let finishFirst!: () => void
+
+  before(async () => {
+    const limiter = new ConcurrencyLimiter(1)
+    const app = express()
+    let requests = 0
+    app.get('/file', createDownloadAdmission(limiter), (_req, res) => {
+      requests += 1
+      if (requests === 1) {
+        finishFirst = () => res.send('first')
+        return
+      }
+      res.send('next')
+    })
+    const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
+      const listener = app.listen(0, '127.0.0.1', () => resolve(listener))
+    })
+    const address = server.address() as AddressInfo
+    url = `http://127.0.0.1:${address.port}`
+    close = () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+  })
+
+  after(async () => close?.())
+
+  it('returns 429 while the global slot is occupied and releases it on completion', async () => {
+    const first = fetch(`${url}/file`)
+    while (finishFirst === undefined) await new Promise((resolve) => setImmediate(resolve))
+
+    const rejected = await fetch(`${url}/file`)
+    assert.equal(rejected.status, 429)
+    assert.equal(rejected.headers.get('retry-after'), '5')
+
+    finishFirst()
+    assert.equal((await first).status, 200)
+    assert.equal((await fetch(`${url}/file`)).status, 200)
+  })
+})

--- a/test/downloadAdmission.test.ts
+++ b/test/downloadAdmission.test.ts
@@ -48,3 +48,56 @@ describe('download concurrency admission', () => {
     assert.equal((await fetch(`${url}/file`)).status, 200)
   })
 })
+
+describe('per-client download share', () => {
+  let url = ''
+  let close: (() => Promise<void>) | undefined
+  let release!: () => void
+  let client = 'first'
+
+  before(async () => {
+    // Room to spare globally, so only the per-client share can refuse a request.
+    const limiter = new ConcurrencyLimiter(8)
+    const app = express()
+    let held = 0
+    app.get(
+      '/file',
+      createDownloadAdmission(limiter, { perClientLimit: 1, clientKey: () => client }),
+      (_req, res) => {
+        held += 1
+        if (held === 1) {
+          release = () => res.send('held')
+          return
+        }
+        res.send('next')
+      }
+    )
+    const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
+      const listener = app.listen(0, '127.0.0.1', () => resolve(listener))
+    })
+    const address = server.address() as AddressInfo
+    url = `http://127.0.0.1:${address.port}`
+    close = () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+  })
+
+  after(async () => close?.())
+
+  it('refuses one address beyond its share while others still get slots', async () => {
+    const held = fetch(`${url}/file`)
+    while (release === undefined) await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal((await fetch(`${url}/file`)).status, 429)
+
+    // A different address is unaffected: the global limiter still has room.
+    client = 'second'
+    assert.equal((await fetch(`${url}/file`)).status, 200)
+
+    client = 'first'
+    release()
+    assert.equal((await held).status, 200)
+    assert.equal((await fetch(`${url}/file`)).status, 200)
+  })
+})

--- a/test/downloadResponse.test.ts
+++ b/test/downloadResponse.test.ts
@@ -71,6 +71,9 @@ describe('download response streaming', () => {
       assert.equal(response.status, 200)
       assert.equal(response.headers.get('content-type'), 'application/octet-stream')
       assert.equal(response.headers.get('content-disposition'), 'attachment; filename="bafytest"')
+      assert.equal(response.headers.get('etag'), '"bafytest"')
+      assert.equal(response.headers.get('accept-ranges'), 'none')
+      assert.match(response.headers.get('cache-control') ?? '', /immutable/)
       await assert.rejects(response.arrayBuffer())
       assert.equal(lateErrors, 1)
     } finally {

--- a/test/downloadResponse.test.ts
+++ b/test/downloadResponse.test.ts
@@ -4,10 +4,18 @@ import { Readable } from 'node:stream'
 import { describe, it } from 'node:test'
 import express, { type Express } from 'express'
 import { getPublicError } from '../src/security/errors.js'
-import { sendDownloadStream } from '../src/utils/downloadResponse.js'
+import { matchesDownloadEtag, sendDownloadStream } from '../src/utils/downloadResponse.js'
 import { FileNotFoundError } from '../src/utils/fileErrors.js'
 
 describe('download response streaming', () => {
+  it('matches strong, weak, list, and wildcard validators for the CID ETag', () => {
+    assert.equal(matchesDownloadEtag('"bafytest"', 'bafytest'), true)
+    assert.equal(matchesDownloadEtag('W/"bafytest"', 'bafytest'), true)
+    assert.equal(matchesDownloadEtag('"other", "bafytest"', 'bafytest'), true)
+    assert.equal(matchesDownloadEtag('*', 'bafytest'), true)
+    assert.equal(matchesDownloadEtag('"other"', 'bafytest'), false)
+  })
+
   it('keeps an early stream error as a controlled JSON response', async () => {
     const app = express()
     app.get('/file', (req, res, next) => {
@@ -73,7 +81,7 @@ describe('download response streaming', () => {
       assert.equal(response.headers.get('content-disposition'), 'attachment; filename="bafytest"')
       assert.equal(response.headers.get('etag'), '"bafytest"')
       assert.equal(response.headers.get('accept-ranges'), 'none')
-      assert.match(response.headers.get('cache-control') ?? '', /immutable/)
+      assert.equal(response.headers.get('cache-control'), 'private, max-age=3600, must-revalidate')
       await assert.rejects(response.arrayBuffer())
       assert.equal(lateErrors, 1)
     } finally {

--- a/test/healthPersistence.test.ts
+++ b/test/healthPersistence.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import { Key } from 'interface-datastore'
+import { FsDatastore } from 'datastore-fs'
+import { loadHealthCheckpoint, saveHealthCheckpoint } from '../src/health/persistence.js'
+import type { HealthCheckpoint } from '../src/health/state.js'
+
+const CHECKPOINT_KEY = new Key('/adm/health/checkpoint')
+const MEMBERSHIP = 'a'.repeat(64)
+const NOW = 1_720_614_998_797
+
+const valid: HealthCheckpoint = {
+  height: 1_720_614_960_000,
+  completedAt: 1_720_614_998_700,
+  membershipVersion: MEMBERSHIP,
+  attestedPeers: 2
+}
+
+let directory: string
+let datastore: FsDatastore
+
+/** Write a raw value under the checkpoint key, bypassing the writer's shape. */
+async function writeRaw(value: unknown): Promise<void> {
+  await datastore.put(CHECKPOINT_KEY, new TextEncoder().encode(JSON.stringify(value)))
+}
+
+before(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'ipfs-node-health-'))
+  datastore = new FsDatastore(join(directory, 'datastore'))
+  await datastore.open()
+})
+
+after(async () => {
+  await datastore.close()
+  await rm(directory, { recursive: true, force: true })
+})
+
+describe('health checkpoint persistence', () => {
+  it('survives a clean restart', async () => {
+    await saveHealthCheckpoint(datastore, valid)
+
+    assert.deepEqual(await loadHealthCheckpoint(datastore, NOW), valid)
+  })
+
+  it('reports no checkpoint when the state was never written', async () => {
+    await datastore.delete(CHECKPOINT_KEY)
+
+    assert.equal(await loadHealthCheckpoint(datastore, NOW), null)
+    await saveHealthCheckpoint(datastore, valid)
+  })
+
+  it('ignores a malformed or truncated record', async () => {
+    await datastore.put(CHECKPOINT_KEY, new TextEncoder().encode('{"height":'))
+    assert.equal(await loadHealthCheckpoint(datastore, NOW), null)
+
+    await writeRaw('not an object')
+    assert.equal(await loadHealthCheckpoint(datastore, NOW), null)
+
+    await writeRaw(null)
+    assert.equal(await loadHealthCheckpoint(datastore, NOW), null)
+  })
+
+  it('rejects negative counts and timestamps', async () => {
+    for (const broken of [
+      { ...valid, height: -1 },
+      { ...valid, completedAt: -1 },
+      { ...valid, attestedPeers: -1 }
+    ]) {
+      await writeRaw(broken)
+      assert.equal(await loadHealthCheckpoint(datastore, NOW), null)
+    }
+  })
+
+  it('rejects a membership version that is not a digest', async () => {
+    for (const version of ['', 'short', 'A'.repeat(64), 'z'.repeat(64)]) {
+      await writeRaw({ ...valid, membershipVersion: version })
+      assert.equal(await loadHealthCheckpoint(datastore, NOW), null)
+    }
+  })
+
+  it('rejects a height that could not belong to the round it claims', async () => {
+    // A round starts at or before the attempt that completed it. A height above
+    // it would be carried forward by `Math.max` and advertised indefinitely.
+    await writeRaw({ ...valid, height: valid.completedAt + 1 })
+    assert.equal(await loadHealthCheckpoint(datastore, NOW), null)
+
+    await writeRaw({ ...valid, height: Number.MAX_SAFE_INTEGER })
+    assert.equal(await loadHealthCheckpoint(datastore, NOW), null)
+  })
+
+  it('rejects a checkpoint from ahead of the clock after a rollback', async () => {
+    await saveHealthCheckpoint(datastore, valid)
+
+    // The clock moved back past the write, so the round it claims never happened
+    // on this node's current timeline.
+    assert.equal(await loadHealthCheckpoint(datastore, valid.completedAt - 3_600_000), null)
+
+    // Movement inside the tolerated skew still loads.
+    assert.deepEqual(await loadHealthCheckpoint(datastore, valid.completedAt - 1_000), valid)
+  })
+})

--- a/test/healthState.test.ts
+++ b/test/healthState.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import type { HealthConfig } from '../src/config.js'
-import { checkpointRound, evaluateHealth } from '../src/health/state.js'
+import { isCompatibleRound } from '../src/health/protocol.js'
+import { checkpointRound, evaluateHealth, refreshHealthSnapshot } from '../src/health/state.js'
 
 const policy: HealthConfig = {
   checkpointIntervalMs: 1_000,
@@ -31,6 +32,11 @@ const healthy = (now: number) => ({
 })
 
 describe('health checkpoint state', () => {
+  it('accepts adjacent fixed rounds during tolerated boundary skew', () => {
+    assert.equal(isCompatibleRound(12_000, 13_000, 1_000), true)
+    assert.equal(isCompatibleRound(12_000, 14_000, 1_000), false)
+  })
+
   it('uses a fixed Unix-millisecond round rather than the request timestamp', () => {
     assert.equal(checkpointRound(12_345, 1_000), 12_000)
     const result = evaluateHealth(policy, healthy(12_345))
@@ -40,6 +46,7 @@ describe('health checkpoint state', () => {
     assert.equal(result.snapshot.timestamp, 12_345)
     assert.equal(result.snapshot.checkpoint.observedAt, 12_345)
     assert.equal(result.snapshot.storage.measurementAgeMs, 0)
+    assert.equal(result.snapshot.storage.reserveHealthy, true)
     assert.equal(result.snapshot.replication.backlog, 0)
   })
 
@@ -92,5 +99,14 @@ describe('health checkpoint state', () => {
     assert.equal(result.snapshot.state, 'degraded')
     assert.equal(result.snapshot.checks.repairFresh, false)
     assert.equal(result.completed, undefined)
+  })
+
+  it('reports a cached ready checkpoint as stale when its age expires', () => {
+    const ready = evaluateHealth(policy, healthy(12_345)).snapshot
+    const refreshed = refreshHealthSnapshot(ready, 16_000)
+
+    assert.equal(refreshed.state, 'stale')
+    assert.equal(refreshed.checkpoint.ageMs, 3_655)
+    assert.equal(refreshed.height, ready.height)
   })
 })

--- a/test/healthState.test.ts
+++ b/test/healthState.test.ts
@@ -23,6 +23,8 @@ const healthy = (now: number) => ({
   storageReservedBytes: 1_000,
   repairRequired: true,
   repairCompletedAt: now,
+  repairHealthy: true,
+  repairBacklog: 0,
   attestedPeers: 1,
   membershipVersion: 'a'.repeat(64),
   previous: null
@@ -33,9 +35,12 @@ describe('health checkpoint state', () => {
     assert.equal(checkpointRound(12_345, 1_000), 12_000)
     const result = evaluateHealth(policy, healthy(12_345))
 
-    assert.equal(result.snapshot.status, 'ready')
+    assert.equal(result.snapshot.state, 'ready')
     assert.equal(result.snapshot.height, 12_000)
     assert.equal(result.snapshot.timestamp, 12_345)
+    assert.equal(result.snapshot.checkpoint.observedAt, 12_345)
+    assert.equal(result.snapshot.storage.measurementAgeMs, 0)
+    assert.equal(result.snapshot.replication.backlog, 0)
   })
 
   it('freezes height when peer coverage is lost', () => {
@@ -46,7 +51,7 @@ describe('health checkpoint state', () => {
       previous: prior
     })
 
-    assert.equal(result.snapshot.status, 'degraded')
+    assert.equal(result.snapshot.state, 'degraded')
     assert.equal(result.snapshot.height, 12_000)
     assert.equal(result.completed, undefined)
   })
@@ -59,7 +64,7 @@ describe('health checkpoint state', () => {
       previous: prior
     })
 
-    assert.equal(result.snapshot.status, 'stale')
+    assert.equal(result.snapshot.state, 'stale')
     assert.equal(result.snapshot.height, prior.height)
   })
 
@@ -74,7 +79,18 @@ describe('health checkpoint state', () => {
       startupHealthy: false
     })
 
-    assert.equal(starting.snapshot.status, 'starting')
-    assert.equal(failed.snapshot.status, 'degraded')
+    assert.equal(starting.snapshot.state, 'starting')
+    assert.equal(failed.snapshot.state, 'degraded')
+  })
+
+  it('does not advance while a known repair backlog remains', () => {
+    const result = evaluateHealth(policy, {
+      ...healthy(12_345),
+      repairBacklog: 1
+    })
+
+    assert.equal(result.snapshot.state, 'degraded')
+    assert.equal(result.snapshot.checks.repairFresh, false)
+    assert.equal(result.completed, undefined)
   })
 })

--- a/test/healthState.test.ts
+++ b/test/healthState.test.ts
@@ -143,6 +143,28 @@ describe('health checkpoint state', () => {
     assert.equal(read.evaluatedAt, 13_000)
   })
 
+  it('refuses to advance while the clock is behind the last checkpoint', () => {
+    const prior = evaluateHealth(policy, healthy(12_345)).completed!
+    // The clock moved back past the checkpoint this node already recorded.
+    const rolledBack = evaluateHealth(policy, { ...healthy(9_000), previous: prior })
+
+    assert.equal(rolledBack.snapshot.checks.clockConsistent, false)
+    assert.notEqual(rolledBack.snapshot.state, 'ready')
+    // Nothing is persisted, so no round can claim to have started after it ended.
+    assert.equal(rolledBack.completed, undefined)
+    assert.equal(rolledBack.snapshot.height, prior.height)
+  })
+
+  it('does not treat a repair completion from the future as fresh', () => {
+    const result = evaluateHealth(policy, {
+      ...healthy(12_345),
+      repairCompletedAt: 20_000
+    })
+
+    assert.equal(result.snapshot.checks.repairFresh, false)
+    assert.notEqual(result.snapshot.state, 'ready')
+  })
+
   it('keeps the maximum checkpoint age inclusive', () => {
     const ready = evaluateHealth(policy, healthy(12_345)).snapshot
     const boundary = refreshHealthSnapshot(ready, 15_345, policy)

--- a/test/healthState.test.ts
+++ b/test/healthState.test.ts
@@ -165,6 +165,21 @@ describe('health checkpoint state', () => {
     assert.notEqual(result.snapshot.state, 'ready')
   })
 
+  it('fails safe on the first read after the clock moves back', () => {
+    const ready = evaluateHealth(policy, healthy(10_000)).snapshot
+    assert.equal(ready.state, 'ready')
+
+    // `age` clamps a negative duration to zero, so without an explicit lower
+    // bound this would read as a brand new observation instead of an impossible
+    // one, and stay `ready` until the next scheduled evaluation.
+    const rolledBack = refreshHealthSnapshot(ready, 5_000, policy)
+
+    assert.equal(rolledBack.checks.clockConsistent, false)
+    assert.equal(rolledBack.checks.checkpointFresh, false)
+    assert.equal(rolledBack.checks.storageFresh, false)
+    assert.equal(rolledBack.state, 'degraded')
+  })
+
   it('keeps the maximum checkpoint age inclusive', () => {
     const ready = evaluateHealth(policy, healthy(12_345)).snapshot
     const boundary = refreshHealthSnapshot(ready, 15_345, policy)

--- a/test/healthState.test.ts
+++ b/test/healthState.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import type { HealthConfig } from '../src/config.js'
+import { checkpointRound, evaluateHealth } from '../src/health/state.js'
+
+const policy: HealthConfig = {
+  checkpointIntervalMs: 1_000,
+  maxCheckpointAgeMs: 3_000,
+  storageMaxAgeMs: 2_000,
+  repairMaxAgeMs: 5_000,
+  clockSkewToleranceMs: 100,
+  peerAttestationTimeoutMs: 100,
+  requiredPeerCount: 1
+}
+
+const healthy = (now: number) => ({
+  now,
+  heliaReady: true,
+  startupComplete: true,
+  startupHealthy: true,
+  storageUpdatedAt: now,
+  storageAvailableBytes: 2_000,
+  storageReservedBytes: 1_000,
+  repairRequired: true,
+  repairCompletedAt: now,
+  attestedPeers: 1,
+  membershipVersion: 'a'.repeat(64),
+  previous: null
+})
+
+describe('health checkpoint state', () => {
+  it('uses a fixed Unix-millisecond round rather than the request timestamp', () => {
+    assert.equal(checkpointRound(12_345, 1_000), 12_000)
+    const result = evaluateHealth(policy, healthy(12_345))
+
+    assert.equal(result.snapshot.status, 'ready')
+    assert.equal(result.snapshot.height, 12_000)
+    assert.equal(result.snapshot.timestamp, 12_345)
+  })
+
+  it('freezes height when peer coverage is lost', () => {
+    const prior = evaluateHealth(policy, healthy(12_345)).completed!
+    const result = evaluateHealth(policy, {
+      ...healthy(13_456),
+      attestedPeers: 0,
+      previous: prior
+    })
+
+    assert.equal(result.snapshot.status, 'degraded')
+    assert.equal(result.snapshot.height, 12_000)
+    assert.equal(result.completed, undefined)
+  })
+
+  it('reports stale after the last valid checkpoint exceeds its age bound', () => {
+    const prior = evaluateHealth(policy, healthy(12_345)).completed!
+    const result = evaluateHealth(policy, {
+      ...healthy(16_000),
+      storageUpdatedAt: 12_345,
+      previous: prior
+    })
+
+    assert.equal(result.snapshot.status, 'stale')
+    assert.equal(result.snapshot.height, prior.height)
+  })
+
+  it('distinguishes incomplete startup from a failed reconciliation', () => {
+    const starting = evaluateHealth(policy, {
+      ...healthy(12_345),
+      startupComplete: false,
+      startupHealthy: false
+    })
+    const failed = evaluateHealth(policy, {
+      ...healthy(12_345),
+      startupHealthy: false
+    })
+
+    assert.equal(starting.snapshot.status, 'starting')
+    assert.equal(failed.snapshot.status, 'degraded')
+  })
+})

--- a/test/healthState.test.ts
+++ b/test/healthState.test.ts
@@ -123,6 +123,26 @@ describe('health checkpoint state', () => {
     assert.equal(repairExpired.checks.repairFresh, false)
   })
 
+  it('dates non-checkpoint evidence by the attempt, not by the last success', () => {
+    const prior = evaluateHealth(policy, healthy(12_345)).completed!
+    const failed = evaluateHealth(policy, {
+      ...healthy(13_000),
+      attestedPeers: 0,
+      previous: prior
+    }).snapshot
+
+    // The attempt at 13_000 produced membership and checks; observedAt still
+    // points at the successful round, so the two must not share a timestamp.
+    assert.equal(failed.evaluatedAt, 13_000)
+    assert.equal(failed.checkpoint.observedAt, 12_345)
+    assert.equal(failed.membership.attestedPeers, 0)
+
+    // A read moves `timestamp` but must not move the evaluation time with it.
+    const read = refreshHealthSnapshot(failed, 13_500, policy)
+    assert.equal(read.timestamp, 13_500)
+    assert.equal(read.evaluatedAt, 13_000)
+  })
+
   it('keeps the maximum checkpoint age inclusive', () => {
     const ready = evaluateHealth(policy, healthy(12_345)).snapshot
     const boundary = refreshHealthSnapshot(ready, 15_345, policy)

--- a/test/healthState.test.ts
+++ b/test/healthState.test.ts
@@ -103,10 +103,31 @@ describe('health checkpoint state', () => {
 
   it('reports a cached ready checkpoint as stale when its age expires', () => {
     const ready = evaluateHealth(policy, healthy(12_345)).snapshot
-    const refreshed = refreshHealthSnapshot(ready, 16_000)
+    const refreshed = refreshHealthSnapshot(ready, 16_000, policy)
 
     assert.equal(refreshed.state, 'stale')
+    assert.equal(refreshed.checks.checkpointFresh, false)
     assert.equal(refreshed.checkpoint.ageMs, 3_655)
     assert.equal(refreshed.height, ready.height)
+  })
+
+  it('expires cached storage and repair checks before the next checkpoint tick', () => {
+    const ready = evaluateHealth(policy, healthy(12_345)).snapshot
+    const storageExpired = refreshHealthSnapshot(ready, 14_500, policy)
+    const repairExpired = refreshHealthSnapshot(ready, 17_500, policy)
+
+    assert.equal(storageExpired.state, 'degraded')
+    assert.equal(storageExpired.checks.storageFresh, false)
+    assert.equal(storageExpired.checks.repairFresh, true)
+    assert.equal(repairExpired.state, 'stale')
+    assert.equal(repairExpired.checks.repairFresh, false)
+  })
+
+  it('keeps the maximum checkpoint age inclusive', () => {
+    const ready = evaluateHealth(policy, healthy(12_345)).snapshot
+    const boundary = refreshHealthSnapshot(ready, 15_345, policy)
+
+    assert.notEqual(boundary.state, 'stale')
+    assert.equal(boundary.checkpoint.ageMs, boundary.checkpoint.maxAgeMs)
   })
 })

--- a/test/integration/replicationProtocol.test.ts
+++ b/test/integration/replicationProtocol.test.ts
@@ -20,6 +20,7 @@ import {
   type ReplicationHandlers
 } from '../../src/storage/replicationProtocol.js'
 import { deterministicBytes } from '../fixtures.js'
+import { registerHealthProtocol, requestHealthAttestation } from '../../src/health/protocol.js'
 
 /** Only loopback, and port 0 so the OS picks a free port. */
 const LISTEN = ['/ip4/127.0.0.1/tcp/0']
@@ -60,6 +61,9 @@ let refusals: string[]
 let hasRoom = true
 let committed: string[]
 let aborted: string[]
+let healthAuthorized: Set<string>
+const HEALTH_MEMBERSHIP = 'a'.repeat(64)
+const HEALTH_NOW = 1_720_614_998_797
 
 before(async () => {
   sender = await startNode()
@@ -71,6 +75,7 @@ before(async () => {
   refusals = []
   committed = []
   aborted = []
+  healthAuthorized = new Set([sender.node.libp2p.peerId.toString()])
 
   const handlers: ReplicationHandlers = {
     isAuthorized: (peerId) => authorized.has(peerId),
@@ -104,9 +109,67 @@ before(async () => {
   }
 
   await registerReplicationProtocol(holder.node, handlers)
+  await registerHealthProtocol(holder.node, {
+    timeoutMs: 1_000,
+    checkpointIntervalMs: 60_000,
+    clockSkewToleranceMs: 10_000,
+    membershipVersion: HEALTH_MEMBERSHIP,
+    authorizedPeerIds: healthAuthorized,
+    now: () => HEALTH_NOW
+  })
 
   // The holder pulls blocks over this connection, so it has to exist first
   await sender.node.libp2p.dial(holder.node.libp2p.getMultiaddrs())
+})
+
+describe('health attestations over libp2p', () => {
+  it('accepts the same fixed round from an authorized configured peer', async () => {
+    await requestHealthAttestation(
+      sender.node,
+      holder.node.libp2p.getMultiaddrs()[0],
+      {
+        round: Math.floor(HEALTH_NOW / 60_000) * 60_000,
+        timestamp: HEALTH_NOW,
+        membershipVersion: HEALTH_MEMBERSHIP
+      },
+      { timeoutMs: 1_000, clockSkewToleranceMs: 10_000 }
+    )
+  })
+
+  it('rejects a different membership version', async () => {
+    await assert.rejects(
+      requestHealthAttestation(
+        sender.node,
+        holder.node.libp2p.getMultiaddrs()[0],
+        {
+          round: Math.floor(HEALTH_NOW / 60_000) * 60_000,
+          timestamp: HEALTH_NOW,
+          membershipVersion: 'b'.repeat(64)
+        },
+        { timeoutMs: 1_000, clockSkewToleranceMs: 10_000 }
+      )
+    )
+  })
+
+  it('rejects a peer outside the configured membership', async () => {
+    healthAuthorized.clear()
+    try {
+      await assert.rejects(
+        requestHealthAttestation(
+          sender.node,
+          holder.node.libp2p.getMultiaddrs()[0],
+          {
+            round: Math.floor(HEALTH_NOW / 60_000) * 60_000,
+            timestamp: HEALTH_NOW,
+            membershipVersion: HEALTH_MEMBERSHIP
+          },
+          { timeoutMs: 1_000, clockSkewToleranceMs: 10_000 }
+        )
+      )
+    } finally {
+      healthAuthorized.add(sender.node.libp2p.peerId.toString())
+    }
+  })
 })
 
 after(async () => {

--- a/test/integration/replicationProtocol.test.ts
+++ b/test/integration/replicationProtocol.test.ts
@@ -136,6 +136,21 @@ describe('health attestations over libp2p', () => {
     )
   })
 
+  it('accepts an adjacent fixed round from an authorized peer', async () => {
+    const localRound = Math.floor(HEALTH_NOW / 60_000) * 60_000
+
+    await requestHealthAttestation(
+      sender.node,
+      holder.node.libp2p.getMultiaddrs()[0],
+      {
+        round: localRound - 60_000,
+        timestamp: HEALTH_NOW,
+        membershipVersion: HEALTH_MEMBERSHIP
+      },
+      { timeoutMs: 1_000, clockSkewToleranceMs: 10_000 }
+    )
+  })
+
   it('rejects a different membership version', async () => {
     await assert.rejects(
       requestHealthAttestation(

--- a/test/logCapture.test.ts
+++ b/test/logCapture.test.ts
@@ -39,6 +39,19 @@ describe('application log sanitization', () => {
     assert.equal(output.includes('kept the local copy instead'), true)
   })
 
+  it('covers CID forms a length threshold would miss', () => {
+    const { logger, lines } = capture()
+    // Valid CIDv1 with an identity multihash: 32 characters, well under the
+    // length of the common sha2-256 form.
+    const shortCid = 'bafkqad3qojuxmylumuqhaylznrxwcza'
+
+    logger.error(`Cannot pin ${shortCid}`)
+
+    const output = lines()
+    assert.equal(output.includes(shortCid), false)
+    assert.equal(output.includes('[cid]'), true)
+  })
+
   it('keeps peer identities and multiaddrs out of a message', () => {
     const { logger, lines } = capture()
 

--- a/test/logCapture.test.ts
+++ b/test/logCapture.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import { Writable } from 'node:stream'
+import { describe, it } from 'node:test'
+import { createApplicationLogger } from '../src/utils/logger.js'
+
+const CID_V1 = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+const CID_V0 = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
+const PEER_ID = '12D3KooWSUCe86zWfas1Lo1UQzXzquZgS81d1DpPPYAuTNjSyniq'
+const MULTIADDR = `/ip4/194.163.154.252/tcp/4001/p2p/${PEER_ID}`
+
+/** Collect what the wired logger actually writes, not what a call site intended. */
+function capture(): { logger: ReturnType<typeof createApplicationLogger>; lines: () => string } {
+  let written = ''
+  const destination = new Writable({
+    write(chunk, unusedEncoding, done) {
+      written += String(chunk)
+      done()
+    }
+  })
+
+  return {
+    logger: createApplicationLogger({ level: 'debug', destination }),
+    lines: () => written
+  }
+}
+
+describe('application log sanitization', () => {
+  it('keeps content identifiers out of a template message', () => {
+    const { logger, lines } = capture()
+
+    logger.info(`No configured node reports holding ${CID_V1}`)
+    logger.warn(`No node was holding ${CID_V0}; kept the local copy instead`)
+
+    const output = lines()
+    assert.equal(output.includes(CID_V1), false)
+    assert.equal(output.includes(CID_V0), false)
+    assert.equal(output.includes('[cid]'), true)
+    // The operational meaning of the message survives the scrub.
+    assert.equal(output.includes('kept the local copy instead'), true)
+  })
+
+  it('keeps peer identities and multiaddrs out of a message', () => {
+    const { logger, lines } = capture()
+
+    logger.info(`Helia is running! PeerID: ${PEER_ID}`)
+    logger.info(`Start peering ipfs1 node (${MULTIADDR})...`)
+
+    const output = lines()
+    assert.equal(output.includes(PEER_ID), false)
+    assert.equal(output.includes('194.163.154.252'), false)
+    assert.equal(output.includes('[peer]'), true)
+    assert.equal(output.includes('[multiaddr]'), true)
+  })
+
+  it('scrubs structured fields, not only the message', () => {
+    const { logger, lines } = capture()
+
+    logger.info({ event: 'replication_repair_pass', cursor: CID_V1, peers: [PEER_ID] }, 'pass')
+
+    const output = lines()
+    assert.equal(output.includes(CID_V1), false)
+    assert.equal(output.includes(PEER_ID), false)
+    assert.equal(output.includes('replication_repair_pass'), true)
+  })
+
+  it('reports an error without its stack', () => {
+    const { logger, lines } = capture()
+    const failure = Object.assign(new Error(`Cannot pin ${CID_V1}`), { code: 'ERR_NOT_FOUND' })
+
+    logger.error({ err: failure }, 'Repair pass failed')
+    logger.error(failure)
+
+    const output = lines()
+    assert.equal(output.includes('    at '), false)
+    assert.equal(output.includes(CID_V1), false)
+    assert.equal(output.includes('ERR_NOT_FOUND'), true)
+    assert.equal(output.includes('Repair pass failed'), true)
+  })
+
+  it('drops a stack that reached the message as text', () => {
+    const { logger, lines } = capture()
+
+    logger.error(`Scan failed: boom\n    at scan (/srv/ipfs-node/dist/scan.js:12:9)`)
+
+    const output = lines()
+    assert.equal(output.includes('    at scan'), false)
+    assert.equal(output.includes('[stack omitted]'), true)
+    assert.equal(output.includes('Scan failed: boom'), true)
+  })
+
+  it('leaves ordinary operational text alone', () => {
+    const { logger, lines } = capture()
+
+    logger.info('Upload request carries 3 file(s)')
+    logger.info({ event: 'storage_demoted_record', holders: 2 }, 'Released a local copy')
+
+    const output = lines()
+    assert.equal(output.includes('Upload request carries 3 file(s)'), true)
+    assert.equal(output.includes('"holders":2'), true)
+    assert.equal(output.includes('[cid]'), false)
+  })
+})

--- a/test/logCapture.test.ts
+++ b/test/logCapture.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import { Writable } from 'node:stream'
 import { describe, it } from 'node:test'
+import { CID } from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+import { identity } from 'multiformats/hashes/identity'
 import { createApplicationLogger } from '../src/utils/logger.js'
 
 const CID_V1 = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
@@ -41,15 +44,19 @@ describe('application log sanitization', () => {
 
   it('covers CID forms a length threshold would miss', () => {
     const { logger, lines } = capture()
-    // Valid CIDv1 with an identity multihash: 32 characters, well under the
-    // length of the common sha2-256 form.
-    const shortCid = 'bafkqad3qojuxmylumuqhaylznrxwcza'
+    // Identity multihash over empty bytes: `bafkqaaa`, the shortest CID there
+    // is, and one an all-CID guarantee has to cover like any other.
+    const shortest = CID.createV1(raw.code, identity.digest(new Uint8Array())).toString()
+    const short = 'bafkqad3qojuxmylumuqhaylznrxwcza'
 
-    logger.error(`Cannot pin ${shortCid}`)
+    logger.error(`Cannot pin ${shortest}`)
+    logger.error(`Cannot pin ${short}`)
 
     const output = lines()
-    assert.equal(output.includes(shortCid), false)
-    assert.equal(output.includes('[cid]'), true)
+    assert.equal(shortest, 'bafkqaaa')
+    assert.equal(output.includes(shortest), false)
+    assert.equal(output.includes(short), false)
+    assert.equal(output.match(/\[cid\]/g)?.length, 2)
   })
 
   it('keeps peer identities and multiaddrs out of a message', () => {

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { httpLogSerializers, routeShape } from '../src/utils/logger.js'
+
+const CID = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+
+describe('request logging', () => {
+  it('masks every segment that is not part of a route', () => {
+    assert.equal(routeShape(`/api/file/${CID}`), '/api/file/:param')
+    assert.equal(routeShape(`/api/file/${CID}/status`), '/api/file/:param/status')
+    assert.equal(routeShape(`/api/helia/pins/isPinned/${CID}`), '/api/helia/pins/isPinned/:param')
+  })
+
+  it('keeps static routes readable', () => {
+    assert.equal(routeShape('/api/node/health'), '/api/node/health')
+    assert.equal(routeShape('/api/storage/policy'), '/api/storage/policy')
+    assert.equal(routeShape('/'), '/')
+    assert.equal(routeShape(undefined), '/')
+  })
+
+  it('drops the query string, which is user input like any other', () => {
+    assert.equal(routeShape('/api/storage/gc?dryRun=true'), '/api/storage/gc')
+    assert.equal(routeShape(`/api/file/${CID}?token=secret`), '/api/file/:param')
+  })
+
+  it('serializes a request without its headers or CID', () => {
+    const serialized = httpLogSerializers.req({
+      method: 'GET',
+      url: `/api/file/${CID}`,
+      // Present on the real request object; must not reach the log.
+      headers: { 'x-api-key': 'a'.repeat(64), authorization: 'Bearer token' }
+    } as unknown as { method?: string; url?: string })
+
+    assert.deepEqual(serialized, { method: 'GET', url: '/api/file/:param' })
+    assert.equal(JSON.stringify(serialized).includes('a'.repeat(64)), false)
+    assert.equal(JSON.stringify(serialized).includes(CID), false)
+  })
+
+  it('serializes a response without the CID-bearing headers', () => {
+    const serialized = httpLogSerializers.res({
+      statusCode: 200,
+      headers: { etag: `"${CID}"`, 'content-disposition': `attachment; filename="${CID}"` }
+    } as unknown as { statusCode?: number })
+
+    assert.deepEqual(serialized, { statusCode: 200 })
+    assert.equal(JSON.stringify(serialized).includes(CID), false)
+  })
+})

--- a/test/nodeRoutes.test.ts
+++ b/test/nodeRoutes.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict'
 import type { AddressInfo } from 'node:net'
 import { after, before, describe, it } from 'node:test'
-import express from 'express'
+import express, { Router, type Express } from 'express'
 import { createNodeRouters } from '../src/api/nodeRoutes.js'
+import { mountApiRoutes } from '../src/security/accessPolicy.js'
+import { createApiKeyAuth } from '../src/security/apiKey.js'
 import { refreshHealthSnapshot } from '../src/health/state.js'
 import type { HealthSnapshot } from '../src/health/state.js'
 
@@ -60,7 +62,12 @@ describe('node HTTP contract', () => {
           storageMaxAgeMs: 2_000,
           repairMaxAgeMs: 5_000
         }),
-      getHttpMetrics: () => ({ requests: 1 })
+      getHttpMetrics: () => ({ requests: 1 }),
+      getConcurrencyMetrics: () => ({
+        uploads: { active: 1, limit: 32 },
+        incomingCopies: { active: 0, limit: 8 },
+        downloads: { active: 2, limit: 64, perClientLimit: 8 }
+      })
     })
     const app = express()
     app.use('/api/node', routers.publicNodeRouter)
@@ -120,4 +127,126 @@ describe('node HTTP contract', () => {
     assert.equal(body.health.version, '1.2.3')
     assert.equal(body.health.uptimeMs, 5_000)
   })
+
+  it('reports admission-limiter occupancy so a capacity 429 is attributable', async () => {
+    const body = (await (await fetch(`${url}/api/node/details`)).json()) as {
+      concurrency: { downloads: { active: number; limit: number; perClientLimit: number } }
+    }
+
+    assert.deepEqual(body.concurrency.downloads, { active: 2, limit: 64, perClientLimit: 8 })
+  })
 })
+
+/**
+ * The router-level suite above mounts `/details` without the admin boundary.
+ * This one wires the real routers through `mountApiRoutes` and the real
+ * key middleware, so the payload and the boundary are asserted together.
+ */
+describe('node routes behind the mounted access policy', () => {
+  const key = 'c'.repeat(64)
+  let url = ''
+  let close: (() => Promise<void>) | undefined
+
+  before(async () => {
+    const routers = createNodeRouters({
+      version: '1.2.3',
+      now: () => 20_000,
+      uptimeMs: () => 5_000,
+      readLimiter: (_req, _res, next) => next(),
+      getHeliaStatus: () => 'started',
+      getPeerId: () => 'peer-id',
+      getMultiAddresses: () => ['/ip4/127.0.0.1/tcp/4001'],
+      getDiskUsageStats: () => ({
+        blockstoreSizeMb: 1,
+        datastoreSizeMb: 2,
+        availableSizeInMb: 3
+      }),
+      getStorageMetrics: () => ({
+        pinnedBytes: 4,
+        reclaimableBytes: 5,
+        availableBytes: 6,
+        reservedBytes: 7
+      }),
+      getHealthSnapshot: () => health,
+      getHttpMetrics: () => ({ requests: 1 }),
+      getConcurrencyMetrics: () => ({
+        uploads: { active: 1, limit: 32 },
+        incomingCopies: { active: 0, limit: 8 },
+        downloads: { active: 2, limit: 64, perClientLimit: 8 }
+      })
+    })
+    const app = express()
+    const empty = (): Router => Router()
+
+    mountApiRoutes(
+      app,
+      {
+        file: empty(),
+        fileAdminRouter: empty(),
+        publicNodeRouter: routers.publicNodeRouter,
+        node: routers.nodeRouter,
+        helia: empty(),
+        libp2p: empty(),
+        debug: empty(),
+        storage: empty(),
+        storageAdminRouter: empty()
+      },
+      createApiKeyAuth(key),
+      false
+    )
+
+    const server = await startServer(app)
+    url = server.url
+    close = server.close
+  })
+
+  after(async () => close?.())
+
+  it('serves the public routes without a key', async () => {
+    assert.equal((await fetch(`${url}/api/node/health`)).status, 200)
+    assert.equal((await fetch(`${url}/api/node/info`)).status, 200)
+  })
+
+  it('serves the complete operator payload only with a matching key', async () => {
+    assert.equal((await fetch(`${url}/api/node/details`)).status, 401)
+
+    const response = await fetch(`${url}/api/node/details`, { headers: { 'x-api-key': key } })
+    const body = (await response.json()) as Record<string, unknown>
+
+    assert.equal(response.status, 200)
+    for (const field of [
+      'version',
+      'timestamp',
+      'heliaStatus',
+      'peerId',
+      'multiAddresses',
+      'blockstoreSizeMb',
+      'datastoreSizeMb',
+      'availableSizeInMb',
+      'pinnedBytes',
+      'reclaimableBytes',
+      'availableBytes',
+      'reservedBytes',
+      'health',
+      'http',
+      'concurrency'
+    ]) {
+      assert.ok(field in body, `missing ${field}`)
+    }
+  })
+})
+
+async function startServer(app: Express): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = await new Promise<ReturnType<Express['listen']>>((resolve) => {
+    const listener = app.listen(0, '127.0.0.1', () => resolve(listener))
+  })
+  const address = server.address() as AddressInfo
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+  }
+}

--- a/test/nodeRoutes.test.ts
+++ b/test/nodeRoutes.test.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from 'node:net'
 import { after, before, describe, it } from 'node:test'
 import express from 'express'
 import { createNodeRouters } from '../src/api/nodeRoutes.js'
+import { refreshHealthSnapshot } from '../src/health/state.js'
 import type { HealthSnapshot } from '../src/health/state.js'
 
 const health: HealthSnapshot = {
@@ -15,6 +16,7 @@ const health: HealthSnapshot = {
   storage: { measuredAt: 12_345, measurementAgeMs: 0, reserveHealthy: true },
   replication: { repairRequired: true, lastCompleteAt: 12_345, ageMs: 0, backlog: 0 },
   checks: {
+    checkpointFresh: true,
     helia: true,
     startupReconciliation: true,
     storageFresh: true,
@@ -28,15 +30,14 @@ describe('node HTTP contract', () => {
   let url = ''
   let close: (() => Promise<void>) | undefined
   let limited = 0
+  let healthNow = 12_345
 
   before(async () => {
     const routers = createNodeRouters({
       version: '1.2.3',
       now: () => 20_000,
       uptimeMs: () => 5_000,
-      readLimiter: (req, res, next) => {
-        void req
-        void res
+      readLimiter: (_req, _res, next) => {
         limited += 1
         next()
       },
@@ -54,7 +55,11 @@ describe('node HTTP contract', () => {
         availableBytes: 6,
         reservedBytes: 7
       }),
-      getHealthSnapshot: () => health,
+      getHealthSnapshot: () =>
+        refreshHealthSnapshot(health, healthNow, {
+          storageMaxAgeMs: 2_000,
+          repairMaxAgeMs: 5_000
+        }),
       getHttpMetrics: () => ({ requests: 1 })
     })
     const app = express()
@@ -81,7 +86,20 @@ describe('node HTTP contract', () => {
     assert.equal(body.version, '1.2.3')
     assert.equal(body.state, 'ready')
     assert.equal(body.height, 12_000)
+    assert.equal('peerId' in body, false)
+    assert.equal('multiAddresses' in body, false)
+    assert.equal('http' in body, false)
     assert.equal(limited, 0)
+  })
+
+  it('downgrades the cached response to stale on an HTTP read', async () => {
+    healthNow = 16_000
+    const response = await fetch(`${url}/api/node/health`)
+    const body = (await response.json()) as { state: string; checkpoint: { ageMs: number } }
+
+    assert.equal(response.status, 200)
+    assert.equal(body.state, 'stale')
+    assert.equal(body.checkpoint.ageMs, 3_655)
   })
 
   it('rate-limits the legacy public info route', async () => {

--- a/test/nodeRoutes.test.ts
+++ b/test/nodeRoutes.test.ts
@@ -20,6 +20,7 @@ const health: HealthSnapshot = {
   replication: { repairRequired: true, lastCompleteAt: 12_345, ageMs: 0, backlog: 0 },
   checks: {
     checkpointFresh: true,
+    clockConsistent: true,
     helia: true,
     startupReconciliation: true,
     storageFresh: true,

--- a/test/nodeRoutes.test.ts
+++ b/test/nodeRoutes.test.ts
@@ -12,6 +12,7 @@ const health: HealthSnapshot = {
   state: 'ready',
   height: 12_000,
   timestamp: 12_345,
+  evaluatedAt: 12_345,
   checkpoint: { intervalMs: 1_000, observedAt: 12_345, ageMs: 0, maxAgeMs: 3_000 },
   membership: { version: 'a'.repeat(64), requiredPeers: 1, attestedPeers: 1 },
   startup: { complete: true, healthy: true },

--- a/test/nodeRoutes.test.ts
+++ b/test/nodeRoutes.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict'
+import type { AddressInfo } from 'node:net'
+import { after, before, describe, it } from 'node:test'
+import express from 'express'
+import { createNodeRouters } from '../src/api/nodeRoutes.js'
+import type { HealthSnapshot } from '../src/health/state.js'
+
+const health: HealthSnapshot = {
+  state: 'ready',
+  height: 12_000,
+  timestamp: 12_345,
+  checkpoint: { intervalMs: 1_000, observedAt: 12_345, ageMs: 0, maxAgeMs: 3_000 },
+  membership: { version: 'a'.repeat(64), requiredPeers: 1, attestedPeers: 1 },
+  startup: { complete: true, healthy: true },
+  storage: { measuredAt: 12_345, measurementAgeMs: 0, reserveHealthy: true },
+  replication: { repairRequired: true, lastCompleteAt: 12_345, ageMs: 0, backlog: 0 },
+  checks: {
+    helia: true,
+    startupReconciliation: true,
+    storageFresh: true,
+    storageReserve: true,
+    repairFresh: true,
+    peerAttestations: true
+  }
+}
+
+describe('node HTTP contract', () => {
+  let url = ''
+  let close: (() => Promise<void>) | undefined
+  let limited = 0
+
+  before(async () => {
+    const routers = createNodeRouters({
+      version: '1.2.3',
+      now: () => 20_000,
+      uptimeMs: () => 5_000,
+      readLimiter: (req, res, next) => {
+        void req
+        void res
+        limited += 1
+        next()
+      },
+      getHeliaStatus: () => 'started',
+      getPeerId: () => 'peer-id',
+      getMultiAddresses: () => ['/ip4/127.0.0.1/tcp/4001'],
+      getDiskUsageStats: () => ({
+        blockstoreSizeMb: 1,
+        datastoreSizeMb: 2,
+        availableSizeInMb: 3
+      }),
+      getStorageMetrics: () => ({
+        pinnedBytes: 4,
+        reclaimableBytes: 5,
+        availableBytes: 6,
+        reservedBytes: 7
+      }),
+      getHealthSnapshot: () => health,
+      getHttpMetrics: () => ({ requests: 1 })
+    })
+    const app = express()
+    app.use('/api/node', routers.publicNodeRouter)
+    app.use('/api/node', routers.nodeRouter)
+    const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
+      const listener = app.listen(0, '127.0.0.1', () => resolve(listener))
+    })
+    const address = server.address() as AddressInfo
+    url = `http://127.0.0.1:${address.port}`
+    close = () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+  })
+
+  after(async () => close?.())
+
+  it('serves the always-200 health schema without a rate-limit status override', async () => {
+    const response = await fetch(`${url}/api/node/health`)
+    const body = (await response.json()) as Record<string, unknown>
+
+    assert.equal(response.status, 200)
+    assert.equal(body.version, '1.2.3')
+    assert.equal(body.state, 'ready')
+    assert.equal(body.height, 12_000)
+    assert.equal(limited, 0)
+  })
+
+  it('rate-limits the legacy public info route', async () => {
+    assert.equal((await fetch(`${url}/api/node/info`)).status, 200)
+    assert.equal(limited, 1)
+  })
+
+  it('serializes the operator identity and embeds the complete health schema', async () => {
+    const response = await fetch(`${url}/api/node/details`)
+    const body = (await response.json()) as {
+      peerId: string
+      multiAddresses: string[]
+      health: { version: string; uptimeMs: number }
+    }
+
+    assert.equal(body.peerId, 'peer-id')
+    assert.deepEqual(body.multiAddresses, ['/ip4/127.0.0.1/tcp/4001'])
+    assert.equal(body.health.version, '1.2.3')
+    assert.equal(body.health.uptimeMs, 5_000)
+  })
+})

--- a/test/repairCycle.test.ts
+++ b/test/repairCycle.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, beforeEach, describe, it } from 'node:test'
+import { FsDatastore } from 'datastore-fs'
+import { FileRegistry, type FileRecord } from '../src/storage/registry.js'
+import { nextRepairCycleBatch, resetRepairCycle } from '../src/storage/repairCycle.js'
+import { SWEEP_BATCHES } from '../src/storage/sweep.js'
+
+let directory: string
+let datastore: FsDatastore
+let registry: FileRegistry
+let prefixCounter = 0
+
+const record = (cid: string): FileRecord => ({
+  cid,
+  name: cid,
+  state: 'confirmed',
+  createdAt: 1,
+  expiresAt: null,
+  confirmedAt: 1,
+  fileSize: 100,
+  storedBytes: 120,
+  protectedBytes: 120,
+  pinned: true,
+  heldLocally: true,
+  replicas: []
+})
+
+/** Deterministic CIDs that sort in insertion order. */
+const cid = (index: number) => `cid-${String(index).padStart(5, '0')}`
+
+async function seed(count: number, offset = 0): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await registry.withExclusiveCids([cid(offset + index)], async (locked) =>
+      locked.save(record(cid(offset + index)))
+    )
+  }
+}
+
+/** Walk to the end of the cycle, returning every batch it handed out. */
+async function runCycle(): Promise<{
+  visited: string[]
+  last: Awaited<ReturnType<typeof nextRepairCycleBatch>>
+}> {
+  const visited: string[] = []
+  let cursor: string | undefined
+  let last = await nextRepairCycleBatch(registry, cursor)
+
+  for (let pass = 0; pass < 50; pass += 1) {
+    visited.push(...last.cids)
+    if (last.cycleCompleted) break
+    cursor = last.nextCursor
+    last = await nextRepairCycleBatch(registry, cursor)
+  }
+
+  return { visited, last }
+}
+
+before(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'ipfs-node-repair-cycle-'))
+  datastore = new FsDatastore(join(directory, 'datastore'))
+  await datastore.open()
+})
+
+after(async () => {
+  await datastore.close()
+  await rm(directory, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  resetRepairCycle()
+  prefixCounter += 1
+  registry = new FileRegistry(datastore, `/adm/repair-cycle-${prefixCounter}`)
+})
+
+describe('repair cycle candidate list', () => {
+  it('completes over a set that does not change', async () => {
+    await seed(SWEEP_BATCHES.repair + 7)
+
+    const { visited, last } = await runCycle()
+
+    assert.equal(last.cycleCompleted, true)
+    assert.equal(last.uncovered, 0)
+    assert.equal(new Set(visited).size, SWEEP_BATCHES.repair + 7)
+  })
+
+  it('completes immediately on an empty registry', async () => {
+    const batch = await nextRepairCycleBatch(registry, undefined)
+
+    assert.deepEqual(batch.cids, [])
+    assert.equal(batch.cycleCompleted, true)
+    assert.equal(batch.uncovered, 0)
+  })
+
+  it('covers a record admitted behind the cursor before completing', async () => {
+    await seed(SWEEP_BATCHES.repair + 3, 100)
+
+    const first = await nextRepairCycleBatch(registry, undefined)
+    assert.equal(first.cycleCompleted, false)
+
+    // Sorts before everything the first pass handed out, so a cursor-only sweep
+    // would never reach it and would still report a completed cycle.
+    await seed(1, 0)
+
+    const second = await nextRepairCycleBatch(registry, first.nextCursor)
+    assert.equal(second.cycleCompleted, false, 'the arrival extends the cycle instead of ending it')
+
+    const third = await nextRepairCycleBatch(registry, second.nextCursor)
+    assert.equal(third.cids.includes(cid(0)), true)
+    assert.equal(third.cycleCompleted, true)
+    assert.equal(third.uncovered, 0)
+  })
+
+  it('reads the registry once per cycle rather than once per pass', async () => {
+    await seed(SWEEP_BATCHES.repair * 2 + 1)
+
+    let scans = 0
+    const counted = new Proxy(registry, {
+      get(target, property, receiver) {
+        if (property === 'all') {
+          return async () => {
+            scans += 1
+            return target.all()
+          }
+        }
+        return Reflect.get(target, property, receiver) as unknown
+      }
+    })
+
+    let batch = await nextRepairCycleBatch(counted, undefined)
+    while (!batch.cycleCompleted) {
+      batch = await nextRepairCycleBatch(counted, batch.nextCursor)
+    }
+
+    // One scan to build the list, one at the end to name late arrivals.
+    assert.equal(scans, 2)
+  })
+
+  it('rebuilds and resumes from the persisted cursor after a restart', async () => {
+    await seed(SWEEP_BATCHES.repair + 5)
+
+    const first = await nextRepairCycleBatch(registry, undefined)
+    resetRepairCycle()
+
+    const resumed = await nextRepairCycleBatch(registry, first.nextCursor)
+
+    assert.equal(resumed.cids.length, 5)
+    assert.equal(
+      resumed.cids.some((item) => first.cids.includes(item)),
+      false
+    )
+    assert.equal(resumed.cycleCompleted, true)
+  })
+})

--- a/test/repairCycle.test.ts
+++ b/test/repairCycle.test.ts
@@ -142,6 +142,7 @@ describe('repair cycle candidate list', () => {
     await seed(SWEEP_BATCHES.repair + 5)
 
     const first = await nextRepairCycleBatch(registry, undefined)
+    assert.equal(first.coverageProven, true)
     resetRepairCycle()
 
     const resumed = await nextRepairCycleBatch(registry, first.nextCursor)
@@ -152,5 +153,24 @@ describe('repair cycle candidate list', () => {
       false
     )
     assert.equal(resumed.cycleCompleted, true)
+  })
+
+  it('does not claim coverage for a cycle rebuilt after a restart', async () => {
+    await seed(SWEEP_BATCHES.repair + 3, 100)
+
+    const first = await nextRepairCycleBatch(registry, undefined)
+    resetRepairCycle()
+
+    // Admitted while the process was down, sorting before the cursor. The
+    // rebuilt list contains it, so the end-of-cycle scan cannot name it as a
+    // late arrival — the cycle has to say so itself.
+    await seed(1, 0)
+
+    const resumed = await nextRepairCycleBatch(registry, first.nextCursor)
+
+    assert.equal(resumed.cycleCompleted, true)
+    assert.equal(resumed.uncovered, 0)
+    assert.equal(resumed.coverageProven, false)
+    assert.equal(resumed.cids.includes(cid(0)), false)
   })
 })

--- a/test/repairCycleDriver.test.ts
+++ b/test/repairCycleDriver.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { RepairCycleDriver } from '../src/storage/repairCycleDriver.js'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('RepairCycleDriver', () => {
+  it('retries a continuation that fires during a manual pass', async () => {
+    const startupDone = deferred<{ cycleCompleted: boolean }>()
+    const manualDone = deferred<{ cycleCompleted: boolean }>()
+    const continuationDone = deferred<void>()
+    let passes = 0
+    const driver = new RepairCycleDriver({
+      delayMs: 20,
+      busyError: () => new Error('busy'),
+      runPass: () => {
+        passes += 1
+        if (passes === 1) return startupDone.promise
+        if (passes === 2) return manualDone.promise
+        continuationDone.resolve()
+        return Promise.resolve({ cycleCompleted: true })
+      }
+    })
+
+    driver.start()
+    startupDone.resolve({ cycleCompleted: false })
+    await startupDone.promise
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const manual = driver.runManual()
+    // Let the pending automatic continuation fire while the manual pass owns the driver.
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    manualDone.resolve({ cycleCompleted: false })
+    await manual
+    await continuationDone.promise
+
+    assert.equal(passes, 3)
+    await driver.stop()
+  })
+
+  it('rejects a manual pass while automatic repair is active', async () => {
+    const active = deferred<{ cycleCompleted: boolean }>()
+    const driver = new RepairCycleDriver({
+      delayMs: 1,
+      busyError: () => new Error('busy'),
+      runPass: () => active.promise
+    })
+
+    driver.start()
+    await assert.rejects(driver.runManual(), /busy/)
+    active.resolve({ cycleCompleted: true })
+    await driver.stop()
+  })
+})

--- a/test/repairCycleDriver.test.ts
+++ b/test/repairCycleDriver.test.ts
@@ -60,4 +60,79 @@ describe('RepairCycleDriver', () => {
     active.resolve({ cycleCompleted: true })
     await driver.stop()
   })
+
+  it('refuses a manual pass once the driver is stopped', async () => {
+    let passes = 0
+    const driver = new RepairCycleDriver({
+      delayMs: 1,
+      busyError: () => new Error('busy'),
+      runPass: () => {
+        passes += 1
+        return Promise.resolve({ cycleCompleted: true })
+      }
+    })
+
+    driver.start()
+    await driver.stop()
+
+    // Shutdown already awaited the active pass; a pass admitted now would write
+    // cycle evidence against a closing datastore with nothing waiting for it.
+    await assert.rejects(driver.runManual(), /busy/)
+    assert.equal(passes, 1)
+  })
+
+  it('retries a failed pass instead of dropping the cycle', async () => {
+    const results: Array<Promise<{ cycleCompleted: boolean }>> = [
+      Promise.reject(new Error('datastore unavailable')),
+      Promise.resolve({ cycleCompleted: true })
+    ]
+    results[0].catch(() => undefined)
+    const completed = deferred<void>()
+    let passes = 0
+    const driver = new RepairCycleDriver({
+      delayMs: 5,
+      busyError: () => new Error('busy'),
+      runPass: () => {
+        passes += 1
+        const next = results.shift()
+        if (next === undefined) return Promise.resolve({ cycleCompleted: true })
+        if (passes === 2) void next.then(() => completed.resolve())
+        return next
+      },
+      onError: () => undefined
+    })
+
+    driver.start()
+    await completed.promise
+
+    assert.equal(passes, 2)
+    await driver.stop()
+  })
+
+  it('abandons the cycle after repeated failures instead of retrying forever', async () => {
+    const abandoned = deferred<number>()
+    let passes = 0
+    const driver = new RepairCycleDriver({
+      delayMs: 1,
+      maxConsecutiveFailures: 2,
+      busyError: () => new Error('busy'),
+      runPass: () => {
+        passes += 1
+        return Promise.reject(new Error('still failing'))
+      },
+      onError: () => undefined,
+      onAbandon: (unused, failures) => {
+        void unused
+        abandoned.resolve(failures)
+      }
+    })
+
+    driver.start()
+    assert.equal(await abandoned.promise, 2)
+
+    // The budget is spent, so nothing keeps retrying until a new trigger.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    assert.equal(passes, 2)
+    await driver.stop()
+  })
 })

--- a/test/repairEvidence.test.ts
+++ b/test/repairEvidence.test.ts
@@ -25,6 +25,14 @@ describe('persisted repair evidence', () => {
     assert.deepEqual(parseEvidence({ ...valid }, NOW), valid)
   })
 
+  it('rejects a payload that is not an object', () => {
+    // `JSON.parse` legally returns these, and reading a field off one would
+    // throw out of the startup path instead of falling back to an empty cycle.
+    for (const value of [null, 42, 'evidence', true, [valid]]) {
+      assert.equal(parseEvidence(value, NOW), null, JSON.stringify(value))
+    }
+  })
+
   it('rejects a completion stamped ahead of the clock', () => {
     // `evaluateHealth` measures repair freshness from this value, so a future
     // timestamp would read as permanently fresh.

--- a/test/repairEvidence.test.ts
+++ b/test/repairEvidence.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { parseEvidence, type RepairCycleEvidence } from '../src/storage/repairEvidence.js'
+
+const NOW = 1_720_614_998_797
+
+const valid: RepairCycleEvidence = {
+  membershipVersion: 'a'.repeat(64),
+  policyVersion: 'b'.repeat(64),
+  startedAt: NOW - 60_000,
+  superseded: false,
+  examined: 120,
+  checked: 100,
+  underReplicated: 4,
+  repaired: 4,
+  stillMissing: 0,
+  unrecoverable: 0,
+  lastCompletedAt: NOW - 30_000,
+  lastCompletedSuccessfully: true,
+  lastCompletedBacklog: 0
+}
+
+describe('persisted repair evidence', () => {
+  it('accepts state this node could have written', () => {
+    assert.deepEqual(parseEvidence({ ...valid }, NOW), valid)
+  })
+
+  it('rejects a completion stamped ahead of the clock', () => {
+    // `evaluateHealth` measures repair freshness from this value, so a future
+    // timestamp would read as permanently fresh.
+    assert.equal(parseEvidence({ ...valid, lastCompletedAt: NOW + 3_600_000 }, NOW), null)
+    assert.equal(parseEvidence({ ...valid, startedAt: NOW + 1_000 }, NOW), null)
+  })
+
+  it('rejects negative counters', () => {
+    for (const field of [
+      'examined',
+      'checked',
+      'underReplicated',
+      'repaired',
+      'stillMissing',
+      'unrecoverable',
+      'lastCompletedBacklog'
+    ] as const) {
+      assert.equal(parseEvidence({ ...valid, [field]: -1 }, NOW), null, field)
+    }
+  })
+
+  it('rejects internally inconsistent evidence', () => {
+    // More records checked than the cycle ever visited.
+    assert.equal(parseEvidence({ ...valid, examined: 10, checked: 20 }, NOW), null)
+
+    // A clean completion cannot carry a backlog.
+    assert.equal(
+      parseEvidence({ ...valid, lastCompletedSuccessfully: true, lastCompletedBacklog: 3 }, NOW),
+      null
+    )
+  })
+
+  it('accepts a cycle that has never completed', () => {
+    const running = { ...valid, lastCompletedAt: null, lastCompletedSuccessfully: false }
+
+    assert.deepEqual(parseEvidence(running, NOW), running)
+  })
+
+  it('fills in fields written by an earlier release', () => {
+    const legacy = { ...valid }
+    delete (legacy as Partial<RepairCycleEvidence>).examined
+    delete (legacy as Partial<RepairCycleEvidence>).superseded
+
+    const parsed = parseEvidence(legacy, NOW)
+
+    assert.equal(parsed?.examined, valid.checked)
+    assert.equal(parsed?.superseded, false)
+  })
+})

--- a/test/replication.test.ts
+++ b/test/replication.test.ts
@@ -26,7 +26,8 @@ const baseConfig: ReplicationConfig = {
   requestTimeoutMs: 1000,
   repairEnabled: true,
   repairSchedule: '0 * * * * *',
-  repairBatchDelayMs: 1_000
+  repairBatchDelayMs: 1_000,
+  repairProbeConcurrency: 4
 }
 
 const peer = (name: string): ReplicationPeer => ({

--- a/test/replication.test.ts
+++ b/test/replication.test.ts
@@ -25,7 +25,8 @@ const baseConfig: ReplicationConfig = {
   requireQuorumOnUpload: false,
   requestTimeoutMs: 1000,
   repairEnabled: true,
-  repairSchedule: '0 * * * * *'
+  repairSchedule: '0 * * * * *',
+  repairBatchDelayMs: 1_000
 }
 
 const peer = (name: string): ReplicationPeer => ({

--- a/test/retrieval.test.ts
+++ b/test/retrieval.test.ts
@@ -21,7 +21,8 @@ const config: ReplicationConfig = {
   requireQuorumOnUpload: false,
   requestTimeoutMs: 1000,
   repairEnabled: true,
-  repairSchedule: '0 * * * * *'
+  repairSchedule: '0 * * * * *',
+  repairBatchDelayMs: 1_000
 }
 
 const peer = (name: string): ReplicationPeer => ({

--- a/test/retrieval.test.ts
+++ b/test/retrieval.test.ts
@@ -22,7 +22,8 @@ const config: ReplicationConfig = {
   requestTimeoutMs: 1000,
   repairEnabled: true,
   repairSchedule: '0 * * * * *',
-  repairBatchDelayMs: 1_000
+  repairBatchDelayMs: 1_000,
+  repairProbeConcurrency: 4
 }
 
 const peer = (name: string): ReplicationPeer => ({

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -215,9 +215,11 @@ describe('route access policy', () => {
   before(async () => {
     const file = Router().get('/test', (req, res) => res.send({ public: true }))
     const fileAdminRouter = Router().post('/test/confirm', (req, res) => res.send({ admin: true }))
-    const publicNodeRouter = Router().get('/health', (req, res) => res.send({ public: true }))
+    const publicNodeRouter = Router()
+      .get('/health', (req, res) => res.send({ public: true }))
+      .get('/info', (req, res) => res.send({ legacy: true }))
     const node = Router()
-      .get('/info', (req, res) => res.send({ admin: true }))
+      .get('/details', (req, res) => res.send({ admin: true }))
       .get('/future', (req, res) => res.send({ admin: true }))
     const helia = Router().get('/test', (req, res) => res.send({ admin: true }))
     const libp2p = Router().get('/test', (req, res) => res.send({ admin: true }))
@@ -251,8 +253,21 @@ describe('route access policy', () => {
 
   it('keeps health, file transfer, and the storage report public', async () => {
     assert.equal((await fetch(`${serverUrl}/api/node/health`)).status, 200)
+    assert.equal((await fetch(`${serverUrl}/api/node/info`)).status, 200)
     assert.equal((await fetch(`${serverUrl}/api/file/test`)).status, 200)
     assert.equal((await fetch(`${serverUrl}/api/storage/metrics`)).status, 200)
+  })
+
+  it('keeps detailed node identity behind the administrative key', async () => {
+    assert.equal((await fetch(`${serverUrl}/api/node/details`)).status, 401)
+    assert.equal(
+      (
+        await fetch(`${serverUrl}/api/node/details`, {
+          headers: { 'x-api-key': key }
+        })
+      ).status,
+      200
+    )
   })
 
   it('protects the routes that make content durable or reclaim it', async () => {

--- a/test/storageConfig.test.ts
+++ b/test/storageConfig.test.ts
@@ -156,4 +156,9 @@ describe('resolveReplicationConfig', () => {
       /ackQuorum/
     )
   })
+
+  it('validates the pause between bounded repair passes', () => {
+    assert.equal(resolveReplicationConfig({ repairBatchDelayMs: 0 }).repairBatchDelayMs, 0)
+    assert.throws(() => resolveReplicationConfig({ repairBatchDelayMs: -1 }), /repairBatchDelayMs/)
+  })
 })

--- a/test/storageConfig.test.ts
+++ b/test/storageConfig.test.ts
@@ -47,6 +47,15 @@ describe('resolveStorageConfig', () => {
   it('rejects limits that would disable a guarantee', () => {
     assert.throws(() => resolveStorageConfig({ maxConcurrentUploads: 0 }, UPLOAD_LIMIT))
     assert.throws(() => resolveStorageConfig({ maxConcurrentDownloads: 0 }, UPLOAD_LIMIT))
+    assert.throws(() => resolveStorageConfig({ maxConcurrentDownloadsPerClient: 0 }, UPLOAD_LIMIT))
+    assert.throws(
+      () =>
+        resolveStorageConfig(
+          { maxConcurrentDownloads: 4, maxConcurrentDownloadsPerClient: 5 },
+          UPLOAD_LIMIT
+        ),
+      /maxConcurrentDownloadsPerClient/
+    )
     assert.throws(() => resolveStorageConfig({ temporaryTtlMs: 0 }, UPLOAD_LIMIT))
     assert.throws(() => resolveStorageConfig({ diskReserveBytes: -1 }, UPLOAD_LIMIT))
     assert.throws(() => resolveStorageConfig({ confirmationRequired: 'yes' }, UPLOAD_LIMIT))

--- a/test/storageConfig.test.ts
+++ b/test/storageConfig.test.ts
@@ -46,6 +46,7 @@ describe('resolveStorageConfig', () => {
 
   it('rejects limits that would disable a guarantee', () => {
     assert.throws(() => resolveStorageConfig({ maxConcurrentUploads: 0 }, UPLOAD_LIMIT))
+    assert.throws(() => resolveStorageConfig({ maxConcurrentDownloads: 0 }, UPLOAD_LIMIT))
     assert.throws(() => resolveStorageConfig({ temporaryTtlMs: 0 }, UPLOAD_LIMIT))
     assert.throws(() => resolveStorageConfig({ diskReserveBytes: -1 }, UPLOAD_LIMIT))
     assert.throws(() => resolveStorageConfig({ confirmationRequired: 'yes' }, UPLOAD_LIMIT))
@@ -160,5 +161,13 @@ describe('resolveReplicationConfig', () => {
   it('validates the pause between bounded repair passes', () => {
     assert.equal(resolveReplicationConfig({ repairBatchDelayMs: 0 }).repairBatchDelayMs, 0)
     assert.throws(() => resolveReplicationConfig({ repairBatchDelayMs: -1 }), /repairBatchDelayMs/)
+  })
+
+  it('validates repair probe concurrency', () => {
+    assert.equal(resolveReplicationConfig({ repairProbeConcurrency: 8 }).repairProbeConcurrency, 8)
+    assert.throws(
+      () => resolveReplicationConfig({ repairProbeConcurrency: 0 }),
+      /repairProbeConcurrency/
+    )
   })
 })

--- a/test/sweepBatch.test.ts
+++ b/test/sweepBatch.test.ts
@@ -25,17 +25,17 @@ describe('nextSweepBatch', () => {
   it('returns everything when the set fits in one pass', () => {
     const all = records(3)
 
-    assert.deepEqual(nextSweepBatch('rescue', all), all)
+    assert.deepEqual(nextSweepBatch('repair', all), all)
   })
 
   it('covers every record across passes instead of repeating the first ones', () => {
-    const size = SWEEP_BATCHES.rescue
+    const size = SWEEP_BATCHES.repair
     const all = records(size * 2 + 7)
     const seen = new Set<string>()
 
     // Three passes is more than enough to walk a set of this size
     for (let pass = 0; pass < 3; pass += 1) {
-      for (const record of nextSweepBatch('rescue', all)) {
+      for (const record of nextSweepBatch('repair', all)) {
         seen.add(record.cid)
       }
     }
@@ -53,7 +53,7 @@ describe('nextSweepBatch', () => {
     const all = records(SWEEP_BATCHES.repair + 5)
 
     const firstRepair = nextSweepBatch('repair', all)
-    nextSweepBatch('rescue', all)
+    nextSweepBatch('demote', all)
     const secondRepair = nextSweepBatch('repair', all)
 
     assert.notDeepEqual(firstRepair[0], secondRepair[0])
@@ -70,14 +70,14 @@ describe('nextSweepBatch', () => {
   })
 
   it('starts over when the record it stopped at is gone', () => {
-    const all = records(SWEEP_BATCHES.rescue + 3)
-    nextSweepBatch('rescue', all)
+    const all = records(SWEEP_BATCHES.demote + 3)
+    nextSweepBatch('demote', all)
 
-    const replaced = records(SWEEP_BATCHES.rescue + 3).map((record) => ({
+    const replaced = records(SWEEP_BATCHES.demote + 3).map((record) => ({
       cid: `${record.cid}-new`
     }))
 
-    assert.equal(nextSweepBatch('rescue', replaced).length, SWEEP_BATCHES.rescue)
+    assert.equal(nextSweepBatch('demote', replaced).length, SWEEP_BATCHES.demote)
   })
 
   it('does not rewind when the last batch CID left the candidate set', () => {
@@ -105,5 +105,15 @@ describe('nextSweepBatch', () => {
     const second = nextSweepBatch('demote', remaining)
 
     assert.ok(second[0].cid > cursor)
+  })
+
+  it('uses the same code-unit ordering for sorting and cursor resume', () => {
+    const all = [{ cid: 'a' }, { cid: 'B' }, { cid: 'b' }, { cid: 'A' }]
+    const first = sweepBatch('repair', all, 'A')
+
+    assert.deepEqual(
+      first.records.map((record) => record.cid),
+      ['B', 'a', 'b']
+    )
   })
 })

--- a/test/sweepBatch.test.ts
+++ b/test/sweepBatch.test.ts
@@ -1,11 +1,27 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { nextSweepBatch, SWEEP_BATCHES } from '../src/storage/sweep.js'
+import { nextSweepBatch, sweepBatch, SWEEP_BATCHES } from '../src/storage/sweep.js'
 
 const records = (count: number) =>
   Array.from({ length: count }, (unused, i) => ({ cid: `cid-${i}` }))
 
 describe('nextSweepBatch', () => {
+  it('exposes a durable cursor and an unambiguous full-cycle boundary', () => {
+    const all = records(SWEEP_BATCHES.repair + 3)
+    const first = sweepBatch('repair', all)
+    const second = sweepBatch('repair', all, first.nextCursor)
+
+    assert.equal(first.cycleCompleted, false)
+    assert.equal(first.records.length, SWEEP_BATCHES.repair)
+    assert.equal(second.cycleCompleted, true)
+    assert.equal(second.records.length, 3)
+    assert.equal(second.nextCursor, undefined)
+    assert.equal(
+      new Set([...first.records, ...second.records].map((item) => item.cid)).size,
+      all.length
+    )
+  })
+
   it('returns everything when the set fits in one pass', () => {
     const all = records(3)
 

--- a/test/timedStream.test.ts
+++ b/test/timedStream.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { createTimedReadable } from '../src/utils/timedStream.js'
+
+describe('complete stream deadline', () => {
+  it('aborts a transfer that stalls after its first chunk', async () => {
+    async function* source(signal: AbortSignal): AsyncGenerator<Uint8Array> {
+      yield Buffer.from('first')
+      await new Promise<void>((resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    }
+
+    const { stream } = createTimedReadable(source, 20, () => new Error('complete timeout'))
+    const chunks: Buffer[] = []
+
+    await assert.rejects(async () => {
+      for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+    }, /complete timeout/)
+    assert.equal(Buffer.concat(chunks).toString(), 'first')
+  })
+
+  it('propagates external cancellation before the deadline', async () => {
+    const controller = new AbortController()
+    async function* source(signal: AbortSignal): AsyncGenerator<Uint8Array> {
+      if (signal.aborted) throw signal.reason
+      await new Promise<void>((resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+      yield Buffer.alloc(0)
+    }
+    const { stream } = createTimedReadable(
+      source,
+      10_000,
+      () => new Error('timeout'),
+      controller.signal
+    )
+
+    controller.abort(new Error('client left'))
+    await assert.rejects(async () => {
+      for await (const unused of stream) void unused
+    }, /client left/)
+  })
+})

--- a/test/timedStream.test.ts
+++ b/test/timedStream.test.ts
@@ -11,7 +11,11 @@ describe('complete stream deadline', () => {
       })
     }
 
-    const { stream } = createTimedReadable(source, 20, () => new Error('complete timeout'))
+    const { stream } = createTimedReadable(
+      source,
+      { idleTimeoutMs: 20, totalTimeoutMs: 100 },
+      () => new Error('complete timeout')
+    )
     const chunks: Buffer[] = []
 
     await assert.rejects(async () => {
@@ -31,7 +35,7 @@ describe('complete stream deadline', () => {
     }
     const { stream } = createTimedReadable(
       source,
-      10_000,
+      { idleTimeoutMs: 10_000, totalTimeoutMs: 10_000 },
       () => new Error('timeout'),
       controller.signal
     )
@@ -40,5 +44,39 @@ describe('complete stream deadline', () => {
     await assert.rejects(async () => {
       for await (const unused of stream) void unused
     }, /client left/)
+  })
+
+  it('propagates an already-aborted external signal', async () => {
+    const controller = new AbortController()
+    controller.abort(new Error('already gone'))
+    const { stream } = createTimedReadable(
+      async function* () {
+        yield Buffer.from('unexpected')
+      },
+      { idleTimeoutMs: 10_000, totalTimeoutMs: 10_000 },
+      () => new Error('timeout'),
+      controller.signal
+    )
+
+    await assert.rejects(async () => {
+      for await (const unused of stream) void unused
+    }, /already gone/)
+  })
+
+  it('resets the idle deadline while chunks continue arriving', async () => {
+    const { stream } = createTimedReadable(
+      async function* () {
+        for (let index = 0; index < 3; index += 1) {
+          await new Promise((resolve) => setTimeout(resolve, 10))
+          yield Buffer.from(String(index))
+        }
+      },
+      { idleTimeoutMs: 20, totalTimeoutMs: 100 },
+      () => new Error('timeout')
+    )
+
+    const chunks: Buffer[] = []
+    for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+    assert.equal(Buffer.concat(chunks).toString(), '012')
   })
 })


### PR DESCRIPTION
## Description

Add the server-side reliability, health, compatibility, and observability foundation tracked by #23.

- Restore the sanitized public `GET /api/node/info` contract used by the current PWA and iOS application
- Move peer identity, multiaddresses, detailed storage figures, health, and bounded HTTP counters to authenticated `GET /api/node/details`
- Add an always-`200` `GET /api/node/health` response with `starting`, `ready`, `stale`, and `degraded` states
- Persist a monotonic fixed-round checkpoint and validate bounded attestations from configured libp2p peers
- Persist complete replication-repair cycle progress and block checkpoint advancement on stale repair evidence or known backlog
- Apply an idle and a size-aware complete-transfer timeout to the download, cancel retrieval after client disconnect, add CID `ETag`s with private revalidated caching and `304` handling, and ignore `Range` while returning the complete `200` representation with `Accept-Ranges: none`
- Emit production JSON logs by default, add bounded request metrics and a `typecheck` script, and document the stable API in OpenAPI 3.1

The health response contains bounded aggregate evidence only. It does not expose CIDs, filenames, peer identities, multiaddresses, secrets, or user activity timestamps.

Existing configuration files remain valid because the new `health` section and `prettyLogs` setting have safe defaults. Current PWA and iOS releases continue to use the unchanged legacy fields and types from public `/api/node/info` without an administrative key.

Operational rollout must update enough IPFS nodes to satisfy `health.requiredPeerCount` before routing new work by the checkpoint state. The legacy endpoint remains in place until the separately versioned PWA and iOS migration is complete.

## Related issue

Related to #23

This PR implements the IPFS-node server scope. Client migration, mixed old/new fleet verification, minimum supported client versions, active-shutdown coverage, and the remaining production operations runbook stay tracked by the composite issue and should not be closed by this PR.

## How to test

```bash
npm run typecheck
npm run lint
npm run format
npm run build
npm test
npm run security:audit
npm run security:semgrep
git diff --check origin/dev...HEAD
```

Validation completed on Node.js 24:

- 292 unit tests passed
- 106 integration tests passed, including authenticated health attestations
- Production dependency audit reported no unaccepted high or critical vulnerabilities
- Semgrep completed with 0 findings
- OpenAPI YAML parsed successfully

## Checklist

- [x] Repository artifacts and API documentation are in English
- [x] Current PWA and iOS `/api/node/info` compatibility is preserved
- [x] Privileged topology and node identity remain authenticated
- [x] Checkpoint and repair evidence survive clean restarts
- [x] Download timeout and cancellation failure paths are tested
- [x] No new runtime dependency was added
- [x] Focused, unit, integration, build, formatting, audit, and static-analysis checks pass
- [x] Rollout constraints and intentionally deferred cross-repository work are documented

