### PR TITLE
Fix: Reject future observations and bound the log scrubber walk

### DIFF
--- a/src/health/state.ts
+++ b/src/health/state.ts
@@ -85,6 +85,17 @@ function age(now: number, observedAt: number | null): number | null {
   return observedAt === null ? null : Math.max(0, now - observedAt)
 }
 
+/**
+ * Whether an observation could have been made by the time it is being read.
+ *
+ * `age` clamps a negative duration to zero, so a timestamp from ahead of the
+ * clock reads as a brand new observation rather than an impossible one. Every
+ * path that trusts a recorded time checks this first.
+ */
+function notInFuture(now: number, observedAt: number | null): boolean {
+  return observedAt === null || now >= observedAt
+}
+
 /** Return the fixed checkpoint round containing `time`. */
 export function checkpointRound(time: number, intervalMs: number): number {
   return Math.floor(time / intervalMs) * intervalMs
@@ -101,26 +112,33 @@ export function evaluateHealth(
   policy: HealthConfig,
   input: HealthInputs
 ): { snapshot: HealthSnapshot; completed?: HealthCheckpoint } {
+  // Every recorded time this attempt trusts, checked against the same rule the
+  // read-time refresh applies. A clock behind the last checkpoint would keep the
+  // old height through `Math.max` while stamping a lower `completedAt`,
+  // persisting a round that starts after it finished — the shape
+  // `parseCheckpoint` refuses to load. A storage or repair observation from the
+  // future is the same problem without a previous checkpoint to notice it, which
+  // is exactly the state after a rollback that discarded one.
+  const clockConsistent =
+    notInFuture(input.now, input.previous?.completedAt ?? null) &&
+    notInFuture(input.now, input.storageUpdatedAt) &&
+    notInFuture(input.now, input.repairCompletedAt)
+
   const prerequisiteChecks = {
-    // A clock behind the last checkpoint would keep the old height through
-    // `Math.max` while stamping a lower `completedAt`, persisting a round that
-    // starts after it finished — the shape `parseCheckpoint` refuses to load.
-    // Advancement waits for the clock instead of recording that.
-    clockConsistent: input.previous === null || input.previous.completedAt <= input.now,
+    clockConsistent,
     helia: input.heliaReady,
     startupReconciliation: input.startupComplete && input.startupHealthy,
     storageFresh:
+      clockConsistent &&
       input.storageUpdatedAt !== null &&
       input.now - input.storageUpdatedAt <= policy.storageMaxAgeMs,
     storageReserve: input.storageAvailableBytes >= input.storageReservedBytes,
     repairFresh:
       !input.repairRequired ||
-      (input.repairHealthy &&
+      (clockConsistent &&
+        input.repairHealthy &&
         input.repairBacklog === 0 &&
         input.repairCompletedAt !== null &&
-        // A completion stamped ahead of the clock is not evidence of freshness;
-        // without the lower bound its negative age would always pass.
-        input.now >= input.repairCompletedAt &&
         input.now - input.repairCompletedAt <= policy.repairMaxAgeMs),
     peerAttestations: input.attestedPeers >= policy.requiredPeerCount
   }
@@ -200,18 +218,14 @@ export function refreshHealthSnapshot(
   const storageAge = age(timestamp, current.storage.measuredAt)
   const repairAge = age(timestamp, current.replication.lastCompleteAt)
 
-  // `age` clamps a negative duration to zero, so a clock behind the evidence in
-  // this snapshot would read as brand new rather than as impossible. Each
-  // observation is compared against the request time explicitly instead, and the
-  // endpoint fails safe on the first read after a rollback rather than waiting
-  // for the next scheduled evaluation.
-  const notInFuture = (observedAt: number | null): boolean =>
-    observedAt === null || timestamp >= observedAt
+  // The endpoint fails safe on the first read after a rollback rather than
+  // waiting for the next scheduled evaluation. The conjunction keeps it one-way:
+  // a read can clear the flag, never restore it.
   const clockConsistent =
     current.checks.clockConsistent &&
-    notInFuture(current.checkpoint.observedAt) &&
-    notInFuture(current.storage.measuredAt) &&
-    notInFuture(current.replication.lastCompleteAt)
+    notInFuture(timestamp, current.checkpoint.observedAt) &&
+    notInFuture(timestamp, current.storage.measuredAt) &&
+    notInFuture(timestamp, current.replication.lastCompleteAt)
 
   const checks = {
     ...current.checks,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -120,6 +120,18 @@ export function scrubLogValue(value: string): string {
   return scrubCids(scrubbed)
 }
 
+/**
+ * How deep the scrubber walks a structured argument.
+ *
+ * Beyond this the subtree is replaced rather than returned: handing it back
+ * unchanged would let an identifier below the cutoff reach the log, which is
+ * the leak the walk exists to close.
+ */
+const MAX_SCRUB_DEPTH = 4
+
+/** Stands in for a subtree past {@link MAX_SCRUB_DEPTH}. */
+const OMITTED = '[omitted]'
+
 /** Apply {@link scrubLogValue} through the strings of one log argument. */
 function scrubLogArgument(value: unknown, depth = 0): unknown {
   if (typeof value === 'string') {
@@ -139,8 +151,12 @@ function scrubLogArgument(value: unknown, depth = 0): unknown {
     return scrubbed
   }
 
-  if (value === null || typeof value !== 'object' || depth > 4) {
+  if (value === null || typeof value !== 'object') {
     return value
+  }
+
+  if (depth > MAX_SCRUB_DEPTH) {
+    return OMITTED
   }
 
   if (Array.isArray(value)) {

--- a/test/healthState.test.ts
+++ b/test/healthState.test.ts
@@ -165,6 +165,21 @@ describe('health checkpoint state', () => {
     assert.notEqual(result.snapshot.state, 'ready')
   })
 
+  it('refuses a storage measurement from ahead of the attempt', () => {
+    // No previous checkpoint to notice the rollback — the state after one that
+    // was discarded, or after a membership change reset it.
+    const result = evaluateHealth(policy, {
+      ...healthy(5_000),
+      storageUpdatedAt: 10_000,
+      previous: null
+    })
+
+    assert.equal(result.snapshot.checks.clockConsistent, false)
+    assert.equal(result.snapshot.checks.storageFresh, false)
+    assert.notEqual(result.snapshot.state, 'ready')
+    assert.equal(result.completed, undefined)
+  })
+
   it('fails safe on the first read after the clock moves back', () => {
     const ready = evaluateHealth(policy, healthy(10_000)).snapshot
     assert.equal(ready.state, 'ready')

--- a/test/logCapture.test.ts
+++ b/test/logCapture.test.ts
@@ -83,6 +83,16 @@ describe('application log sanitization', () => {
     assert.equal(output.includes('replication_repair_pass'), true)
   })
 
+  it('omits a subtree past the depth limit rather than passing it through', () => {
+    const { logger, lines } = capture()
+
+    logger.info({ a: { b: { c: { d: { e: { cid: CID_V1 } } } } } }, 'nested')
+
+    const output = lines()
+    assert.equal(output.includes(CID_V1), false)
+    assert.equal(output.includes('[omitted]'), true)
+  })
+
   it('reports an error without its stack', () => {
     const { logger, lines } = capture()
     const failure = Object.assign(new Error(`Cannot pin ${CID_V1}`), { code: 'ERR_NOT_FOUND' })


### PR DESCRIPTION
## Description

Follow-up to #32, which merged before the last review round's fixes were applied. Both come from review threads on that PR and are gaps left by its own earlier fixes rather than new ground.

- Compute clock consistency across every recorded time a checkpoint attempt trusts, not only the previous checkpoint
- Replace a subtree past the log scrubber's depth limit instead of returning it unchanged

### A future storage measurement no longer completes a checkpoint

`evaluateHealth` kept only an upper age bound on `storageFresh`, and `clockConsistent` looked at `previous.completedAt` alone — so with no previous checkpoint nothing was watching. That is the state after a rollback that discarded one, or after a membership change reset it. With `now: 5000` and `storageUpdatedAt: 10000` the node reported `ready` and persisted a checkpoint.

A single `notInFuture(now, observedAt)` helper is now shared by `evaluateHealth` and `refreshHealthSnapshot`, and `clockConsistent` covers the previous checkpoint, the storage measurement, and the repair completion, with `storageFresh` and `repairFresh` gated on it. The two paths applying identical semantics is the point: hand-written variants drifting apart is how this gap survived the round that added the same bound elsewhere.

### The scrubber no longer hands back a subtree at its depth limit

Returning the object unchanged past `depth > 4` was the one branch of the walk that returned data instead of sanitizing it, so a CID nested below the cutoff reached the log intact. The structure is replaced with a fixed `[omitted]` marker, and the depth test moved below the primitive check so a scalar at any depth is still returned on its own terms. Strings were never affected, being scrubbed by the first branch regardless of depth.

## Related issue

Related to #23. Follow-up to #32.

## How to test

```bash
npm run typecheck
npm run lint
npm run format
npm run build
npm test
```

Validation completed on Node.js 24:

- 309 unit tests passed
- 106 integration tests passed
- Two regressions added, reproducing both reports directly: `now: 5000` with `storageUpdatedAt: 10000` and no previous checkpoint, and a CID five object levels deep

## Checklist

- [x] Repository artifacts and API documentation are in English
- [x] No public response contract changed; `checks.clockConsistent` keeps its meaning and is only computed from more evidence
- [x] No new runtime dependency was added
- [x] Focused, unit, integration, build, formatting, and static-analysis checks pass
- [x] Both review threads on #32 are addressed
